### PR TITLE
refactor: Refactor fast lap display for better readability and usability

### DIFF
--- a/components/paddock/paddock/templates/fastlap_index.html
+++ b/components/paddock/paddock/templates/fastlap_index.html
@@ -4,14 +4,22 @@
   <div class="card-body">
     <div class="container">
       <div class="row">
-        <div class="col-sm-6">
+        <div class="col-sm-12">
           <h3>Coaches</h3>
-
-          <ul>
+          <table>
+            <tr>
+              <th>game</th>
+              <th>car</th>
+              <th>track</th>
+            </tr>
             {% for lap in fast_laps %}
-            <li><a href="/fastlap/{{ lap.pk }}">{{ lap }}</a></li>
+            <tr>
+              <td>{{ lap.game }}</td>
+              <td>{{ lap.car }}</td>
+              <td><a href="/fastlap/{{ lap.pk }}">{{ lap.track }}</a></td>
+            </tr>
             {% endfor %}
-          </ul>
+          </table>
         </div>
       </div>
     </div>

--- a/components/paddock/paddock/views.py
+++ b/components/paddock/paddock/views.py
@@ -15,9 +15,9 @@ def fastlap_view(request, template_name="fastlap.html", fastlap_id="", **kwargs)
 
 def fastlap_index(request, template_name="fastlap_index.html"):
     # fast_laps = FastLap.objects.filter(driver=None).all()
-    fast_laps = (
-        FastLap.objects.select_related("game", "car", "track").filter(driver=None).all()
-    )
+    fast_laps = FastLap.objects.select_related("game", "car", "track").filter(driver=None).all()
+    # sort by str representation of fastlap
+    fast_laps = sorted(fast_laps, key=lambda x: str(x))
     context = {
         "fast_laps": fast_laps,
     }


### PR DESCRIPTION
- Remove commented-out code and unnecessary parentheses in paddock/views.py
- Sort FastLap objects in `fast_laps` by string representation
- Update layout of fast lap page to span entire width
- Replace list with table for fast lap display on home page
- Add game and car columns to fast lap table on home page
