### PR TITLE
ingress follow up

### DIFF
--- a/manifests/base/paddock/kustomization.yaml
+++ b/manifests/base/paddock/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 resources:
   - deployment_config.yaml
   - image_stream.yaml
-  - route.yaml
+  - paddock-ingress.yaml
   - service_account.yaml
   - service_monitor.yaml
   - service.yaml

--- a/manifests/base/paddock/paddock-ingress.yaml
+++ b/manifests/base/paddock/paddock-ingress.yaml
@@ -18,5 +18,5 @@ spec:
                   name: django-web
   tls:
     - hosts:
-        - paddock.b4mad.racing
-      secretName: https-cert-paddock.b4mad.racing
+        - paddock-dev.b4mad.racing
+      secretName: https-cert-paddock-dev.b4mad.racing

--- a/manifests/env/phobos/kustomization.yaml
+++ b/manifests/env/phobos/kustomization.yaml
@@ -71,12 +71,15 @@ patches:
         path: /spec/template/spec/containers/0/resources/limits/memory
         value: "16Gi"
   - target:
-      kind: Route
+      kind: Ingress
       name: paddock
     patch: |-
       - op: replace
-        path: /spec/host
+        path: /spec/tls/0/hosts/0
         value: paddock.b4mad.racing
+      - op: replace
+        path: /spec/tls/0/secretName
+        value: https-cert-paddock.b4mad.racing
 images:
   - name: paddock
     newName: image-registry.openshift-image-registry.svc:5000/b4mad-racing/paddock


### PR DESCRIPTION
cc @goern @anton264 

this way I'm applying the phobos env.
I'm a bit hesitant to do that 😄  

Will the removal of the route and replacement with ingress work?
Will the secret `https-cert-paddock.b4mad.racing` be created by cert-manager?
Do we need to modify the current cert manager deployment?


Maybe now it's a good time to make the `phobos-dev` environment work and try it out :)