### PR TITLE
bump paddock memory

### DIFF
--- a/manifests/base/paddock/ingress.yaml
+++ b/manifests/base/paddock/ingress.yaml
@@ -3,6 +3,7 @@ kind: Ingress
 metadata:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
+    haproxy.router.openshift.io/timeout: 30s
   name: paddock
 spec:
   rules:

--- a/manifests/env/phobos/kustomization.yaml
+++ b/manifests/env/phobos/kustomization.yaml
@@ -74,6 +74,16 @@ patches:
         path: /spec/template/spec/containers/0/env/3/valueFrom/secretKeyRef/key
         value: token
   - target:
+      kind: DeploymentConfig
+      name: paddock
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/limits/memory
+        value: 2Gi
+      - op: replace
+        path: /spec/template/spec/containers/1/resources/limits/memory
+        value: 2Gi
+  - target:
       kind: Ingress
       name: paddock
     patch: |-


### PR DESCRIPTION
to fix

```
502 Bad Gateway
The server returned an invalid or incomplete response.
```

```
DAMN ! worker 3 (pid: 26) died, killed by signal 9 :( trying respawn ...
Respawned uWSGI worker 3 (new pid: 125)
```