### PR TITLE
Update details-crew-chief.yaml

### DIFF
--- a/manifests/base/grafana-v5/dashboards/details-crew-chief.yaml
+++ b/manifests/base/grafana-v5/dashboards/details-crew-chief.yaml
@@ -17,636 +17,7083 @@ spec:
   #   - name: "michaeldmoore-scatter-panel"
   #     version: "1.1.0"
   json: >
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 31,
+  "links": [],
+  "liveNow": false,
+  "panels": [
     {
-      "annotations": {
-        "list": [
-          {
-            "builtIn": 1,
-            "datasource": "-- Grafana --",
-            "enable": true,
-            "hide": true,
-            "iconColor": "rgba(0, 211, 255, 1)",
-            "name": "Annotations & Alerts",
-            "target": {
-              "limit": 100,
-              "matchAny": false,
-              "tags": [],
-              "type": "dashboard"
-            },
-            "type": "dashboard"
-          },
-          {
-            "datasource": "Racing",
-            "enable": false,
-            "iconColor": "red",
-            "mappings": {
-              "tags": {
-                "source": "field",
-                "value": "CurrentLap {CarModel=\"BMW M3 GT2\", GameName=\"AssettoCorsa\", SessionId=\"5450cced-5b25-4fdd-aeb2-f9a22be6a83e\", TrackCode=\"ks_nordschleife-nordschleife\", UserId=\"41483f24-12e7-40ed-9760-8f642c067c3f\", host=\"telegraf\", topic=\"racing/goern/41483f24-12e7-40ed-9760-8f642c067c3f/5450cced-5b25-4fdd-aeb2-f9a22be6a83e/AssettoCorsa/ks_nordschleife-nordschleife/BMW M3 GT2\", user=\"goern\"}"
-              },
-              "text": {
-                "source": "field",
-                "value": "Value"
-              },
-              "time": {
-                "source": "field",
-                "value": "Time"
-              },
-              "timeEnd": {
-                "source": "field",
-                "value": "Time"
-              },
-              "title": {
-                "source": "field",
-                "value": "Value"
-              }
-            },
-            "name": "lap",
-            "target": {
-              "query": "from(bucket: \"racing\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")  \n  |> filter(fn: (r) => r[\"_field\"] == \"CurrentLapTime\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> sort(columns: [\"_time\"])\n  |> keep(columns: [\"_time\", \"_value\"])\n  |> yield(name: \"mean\")",
-              "refId": "Anno"
-            }
-          }
-        ]
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
       },
-      "editable": true,
-      "fiscalYearStartMonth": 0,
-      "graphTooltip": 0,
-      "iteration": 1664619458885,
-      "links": [],
-      "liveNow": false,
-      "panels": [
-        {
-          "description": "",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "custom": {
-                "align": "auto",
-                "displayMode": "auto"
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
+      "id": 53,
+      "panels": [],
+      "title": "Session ${SessionId} for ${User} details",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "center",
+            "cellOptions": {
+              "type": "auto"
             },
-            "overrides": [
+            "inspect": false,
+            "minWidth": 50
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
               {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Minutes"
-                },
-                "properties": [
-                  {
-                    "id": "decimals",
-                    "value": 3
-                  }
-                ]
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Duration"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "m"
+              },
+              {
+                "id": "custom.width",
+                "value": 124
               }
             ]
           },
-          "gridPos": {
-            "h": 3,
-            "w": 24,
-            "x": 0,
-            "y": 0
-          },
-          "id": 13,
-          "options": {
-            "footer": {
-              "fields": "",
-              "reducer": [
-                "sum"
-              ],
-              "show": false
-            },
-            "showHeader": true,
-            "sortBy": []
-          },
-          "pluginVersion": "8.4.3",
-          "targets": [
-            {
-              "datasource": {
-                "type": "influxdb",
-                "uid": "${DS_RACING}"
-              },
-              "query": "fields = [\"_time\", \"GameName\", \"user\", \"CarModel\", \"TrackCode\", \"SessionId\", \"SessionTypeName\"]\njfields = [\"GameName\", \"user\", \"CarModel\", \"TrackCode\", \"SessionId\", \"SessionTypeName\"]\n\n\ndata = from(bucket: \"racing\")\n  |> range(start: -10y)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\n  |> filter(fn: (r) => r[\"_field\"] == \"CurrentLapTime\")\n  |> keep(columns: fields)\n\nmin = data\n  |> first(column: \"_time\")\n\nmax = data\n  |> last(column: \"_time\")\n\njoin(tables: {min: min, max: max}, on: jfields, method: \"inner\")\n  |> group()  \n  |> map(fn: (r) => ({r with Duration: float(v: int(v: duration(v: uint(v: r._time_max) - uint(v: r._time_min))))/60000000000.0}))\n  |> yield()\n",
-              "refId": "A"
-            }
-          ],
-          "title": "Recent Sessions",
-          "transformations": [
-            {
-              "id": "organize",
-              "options": {
-                "excludeByName": {},
-                "indexByName": {
-                  "CarModel": 3,
-                  "Duration": 2,
-                  "GameName": 4,
-                  "SessionId": 5,
-                  "SessionTypeName": 6,
-                  "TrackCode": 7,
-                  "_time_max": 1,
-                  "_time_min": 0,
-                  "user": 8
-                },
-                "renameByName": {
-                  "Duration": "Minutes",
-                  "_time_max": "Stop",
-                  "_time_min": "Start"
-                }
-              }
-            },
-            {
-              "id": "convertFieldType",
-              "options": {
-                "conversions": [],
-                "fields": {}
-              }
-            }
-          ],
-          "type": "table"
-        },
-        {
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "stepAfter",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "displayName": "${__field.name}",
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 11,
-            "w": 24,
-            "x": 0,
-            "y": 3
-          },
-          "id": 2,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom"
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "influxdb",
-                "uid": "${DS_RACING}"
-              },
-              "query": "from(bucket: \"racing\")\n  |> range(start: v.timeRangeStart, stop:v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\n  |> filter(fn: (r) => (r[\"_field\"] == \"Gear\" or r[\"_field\"] == \"Brake\" or r[\"_field\"] == \"SteeringAngle\" or r[\"_field\"] == \"Clutch\" or r[\"_field\"] == \"Throttle\"))\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: \"mean\")\n",
-              "refId": "A"
-            }
-          ],
-          "title": "Inputs",
-          "type": "timeseries"
-        },
-        {
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "stepAfter",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "displayName": "${__field.name} ${__field.labels.CarModel}",
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 5,
-            "w": 24,
-            "x": 0,
-            "y": 14
-          },
-          "id": 14,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom"
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "influxdb",
-                "uid": "${DS_RACING}"
-              },
-              "query": "from(bucket: \"racing\")\n  |> range(start: v.timeRangeStart, stop:v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\n  |> filter(fn: (r) => (r[\"_field\"] == \"DistanceRoundTrack\"))\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: \"mean\")\n",
-              "refId": "A"
-            }
-          ],
-          "title": "Distance Meters",
-          "type": "timeseries"
-        },
-        {
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "stepAfter",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "displayName": "${__field.name} ${__field.labels.CarModel}",
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 5,
-            "w": 24,
-            "x": 0,
-            "y": 19
-          },
-          "id": 15,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom"
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "influxdb",
-                "uid": "${DS_RACING}"
-              },
-              "query": "from(bucket: \"racing\")\n  |> range(start: v.timeRangeStart, stop:v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\n  |> filter(fn: (r) => (r[\"_field\"] == \"SpeedMs\"))\n  |> map(fn: (r) => ({ r with _value: r._value * 3.6 }))\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: \"mean\")\n",
-              "refId": "A"
-            }
-          ],
-          "title": "SpeedKmh",
-          "type": "timeseries"
-        },
-        {
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "stepAfter",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "displayName": "${__field.name} ${__field.labels.CarModel}",
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 5,
-            "w": 24,
-            "x": 0,
-            "y": 24
-          },
-          "id": 16,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom"
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "influxdb",
-                "uid": "${DS_RACING}"
-              },
-              "query": "from(bucket: \"racing\")\n  |> range(start: v.timeRangeStart, stop:v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\n  |> filter(fn: (r) => (r[\"_field\"] == \"Rpms\"))\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: \"mean\")\n",
-              "refId": "A"
-            }
-          ],
-          "title": "RPMs",
-          "type": "timeseries"
-        },
-        {
-          "gridPos": {
-            "h": 8,
-            "w": 24,
-            "x": 0,
-            "y": 29
-          },
-          "id": 11,
-          "options": {
-            "border": {
-              "color": "yellow",
-              "size": 0
-            },
-            "fieldSets": [
-              {
-                "col": 0,
-                "color": "#318596",
-                "dotSize": 3,
-                "hidden": false,
-                "lineSize": 1,
-                "lineType": "simple",
-                "polynomialOrder": 3,
-                "sizeCol": -1
-              },
-              {
-                "col": -1,
-                "color": "#d85443",
-                "dotSize": 2,
-                "hidden": false,
-                "lineSize": 0,
-                "lineType": "simple",
-                "polynomialOrder": 3,
-                "sizeCol": -1
-              }
-            ],
-            "grid": {
-              "color": "gray"
-            },
-            "label": {
-              "col": -1,
-              "color": "#CCC",
-              "textSize": 2
-            },
-            "legend": {
-              "show": false,
-              "size": 3
-            },
-            "xAxis": {
-              "col": 1,
-              "inverted": false
-            },
-            "xAxisExtents": {
-              "min": null,
-              "max": null
-            },
-            "xAxisTitle": {
-              "text": "TrackPositionPercent",
-              "color": "white",
-              "textSize": 2,
-              "rotated": false,
-              "logScale": false
-            },
-            "xMargins": {
-              "lower": 30,
-              "upper": 10
-            },
-            "yAxisExtents": {
-              "min": null,
-              "max": null
-            },
-            "yAxisTitle": {
-              "text": "",
-              "color": "#777",
-              "textSize": 1,
-              "rotated": false,
-              "logScale": false
-            },
-            "yMargins": {
-              "lower": 20,
-              "upper": 20
-            }
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "influxdb",
-                "uid": "${DS_RACING}"
-              },
-              "query": "brake = from(bucket: \"racing\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\n  |> filter(fn: (r) => r[\"_field\"] == \"Brake\")\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n\nx = from(bucket: \"racing\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\n  |> filter(fn: (r) => r[\"_field\"] == \"DistanceRoundTrack\")\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n\njoin(tables: {brake: brake, x: x}, on: [\"_time\"] )\n  |> keep(columns: [\"_value_brake\", \"_value_x\"])\n  |> sort(columns: [\"_value_x\"], desc: false)\n\n",
-              "refId": "A"
-            }
-          ],
-          "title": "Brake on track",
-          "type": "michaeldmoore-scatter-panel"
-        }
-      ],
-      "refresh": false,
-      "schemaVersion": 35,
-      "style": "dark",
-      "tags": [],
-      "templating": {
-        "list": [
           {
-            "current": {
-              "selected": false,
-              "text": "1664554326",
-              "value": "1664554326"
+            "matcher": {
+              "id": "byName",
+              "options": "Game"
             },
-            "hide": 2,
-            "includeAll": false,
-            "label": "SessionId",
-            "multi": false,
-            "name": "SessionId",
-            "options": [
+            "properties": [
               {
-                "selected": false,
-                "text": "49080d03-6f93-47fb-8602-be3dadab2567",
-                "value": "49080d03-6f93-47fb-8602-be3dadab2567"
+                "id": "custom.width",
+                "value": 209
               }
-            ],
-            "query": "49080d03-6f93-47fb-8602-be3dadab2567",
-            "queryValue": "",
-            "skipUrlSync": false,
-            "type": "custom"
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Session Type"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 110
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Duration"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "clockms"
+              },
+              {
+                "id": "decimals",
+                "value": 2
+              },
+              {
+                "id": "custom.width",
+                "value": 200
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Track"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 204
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Stop"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 167
+              },
+              {
+                "id": "unit",
+                "value": "dateTimeFromNow"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Start"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 154
+              },
+              {
+                "id": "unit",
+                "value": "dateTimeFromNow"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Car Model"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 153
+              }
+            ]
           }
         ]
       },
-      "time": {
-        "from": "2022-09-30T16:12:10.668Z",
-        "to": "2022-09-30T16:33:45.086Z"
+      "gridPos": {
+        "h": 4,
+        "w": 24,
+        "x": 0,
+        "y": 1
       },
-      "timepicker": {},
-      "timezone": "",
-      "title": "Session",
-      "uid": "6d57246de74745198b3385f5e446e81cf7127b47",
-      "version": 5,
-      "weekStart": ""
+      "id": 54,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "10.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "query": "import \"date\"\r\nfields = [\"_time\", \"GameName\", \"user\", \"CarModel\", \"TrackCode\", \"SessionId\", \"SessionTypeName\"]\r\njfields = [\"GameName\", \"user\", \"CarModel\", \"TrackCode\", \"SessionId\", \"SessionTypeName\"]\r\n\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\ndata = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"CurrentLapTime\")\r\n  |> keep(columns: fields)\r\n\r\nmin = data\r\n  |> first(column: \"_time\")\r\n\r\nmax = data\r\n  |> last(column: \"_time\")\r\n\r\njoin(tables: {min: min, max: max}, on: jfields, method: \"inner\")\r\n  |> group()  \r\n  \r\n  |> drop(columns: [\"SessionId\",  \"user\" ])\r\n  |> yield()",
+          "refId": "A"
+        }
+      ],
+      "title": "Session Info",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Duration": true
+            },
+            "indexByName": {
+              "CarModel": 4,
+              "Duration": 3,
+              "GameName": 5,
+              "SessionId": 8,
+              "SessionType": 7,
+              "TrackCode": 6,
+              "_time_max": 2,
+              "_time_min": 1,
+              "user": 0
+            },
+            "renameByName": {
+              "CarModel": "Car Model",
+              "Duration": "",
+              "GameName": "Game",
+              "SessionTypeName": "Session Type",
+              "TrackCode": "Track",
+              "_time_max": "Stop",
+              "_time_min": "Start",
+              "user": "User"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Duration",
+            "binary": {
+              "left": "Stop",
+              "operator": "-",
+              "reducer": "sum",
+              "right": "Start"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+      },
+      "description": "Times are base only in valid laps.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "center",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": false,
+            "inspect": false,
+            "minWidth": 50
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Track"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "lengthm"
+              },
+              {
+                "id": "custom.width",
+                "value": 82
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Odometer"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "lengthm"
+              },
+              {
+                "id": "custom.width",
+                "value": 84
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Avg Lap Time"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "clocks"
+              },
+              {
+                "id": "custom.width",
+                "value": 125
+              },
+              {
+                "id": "decimals",
+                "value": 2
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Max Lap Time"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "clocks"
+              },
+              {
+                "id": "custom.width",
+                "value": 128
+              },
+              {
+                "id": "decimals",
+                "value": 2
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Top(Km/h)"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "Speed"
+              },
+              {
+                "id": "decimals",
+                "value": 1
+              },
+              {
+                "id": "custom.width",
+                "value": 104
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Avg(Km/h)"
+            },
+            "properties": [
+              {
+                "id": "decimals",
+                "value": 1
+              },
+              {
+                "id": "unit",
+                "value": "Speed"
+              },
+              {
+                "id": "custom.width",
+                "value": 103
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Total"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 72
+              },
+              {
+                "id": "unit",
+                "value": "Laps"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Avg/Max"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              },
+              {
+                "id": "decimals",
+                "value": 3
+              },
+              {
+                "id": "custom.width",
+                "value": 103
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "P.Top"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 58
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "P.Low"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 56
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Fuel Used"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "litre"
+              },
+              {
+                "id": "custom.width",
+                "value": 88
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Fuel/Lap "
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "litre"
+              },
+              {
+                "id": "custom.width",
+                "value": 81
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Fuel Left "
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 76
+              },
+              {
+                "id": "unit",
+                "value": "litre"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Best Lap Time"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 134
+              },
+              {
+                "id": "unit",
+                "value": "clocks"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "AVG/Best"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 81
+              },
+              {
+                "id": "unit",
+                "value": "s"
+              },
+              {
+                "id": "decimals",
+                "value": 3
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "thresholds"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "text",
+                      "value": null
+                    },
+                    {
+                      "color": "green",
+                      "value": -0.01
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 0.01
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 60,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": [],
+          "reducer": [
+            "changeCount"
+          ],
+          "show": false
+        },
+        "frameIndex": 6,
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "10.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "query": "import \"date\"\r\nFinalOutput = [\"SessionId\", \"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"CurrentLap\" and r._value > 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1d, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value,  _time:r._time, _field:\"Total Laps\"}))\r\n  |> sort(columns: [\"_value\"], desc: false)\r\n  \r\n  |> keep(columns:FinalOutput)\r\n  \r\nNamedSeries |> yield()",
+          "refId": "Total Laps"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "hide": false,
+          "query": "import \"date\"\r\nFinalOutput = [\"SessionId\", \"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Track_Length\" and r._value >= 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1d, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value,  _time:r._time, _field:\"Track_Length\"}))\r\n  |> keep(columns:FinalOutput)\r\nNamedSeries |> yield()",
+          "refId": "Track"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "hide": false,
+          "query": "import \"date\"\r\nFinalOutput = [\"SessionId\", \"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"LapTimePrevious\" and r._value > 0)\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1d, fn: mean, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Avg Lap Time\"}))\r\n  |> keep(columns:FinalOutput)\r\nNamedSeries |> yield()",
+          "refId": "Laps"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "hide": false,
+          "query": "import \"date\"\r\nFinalOutput = [\"SessionId\", \"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"CurrentLapTime\" and r._value > 0)\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1d, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Max Lap Time\"}))\r\n  |> keep(columns:FinalOutput)\r\nNamedSeries |> yield()",
+          "refId": "MaxLap"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "hide": false,
+          "query": "import \"date\"\r\nFinalOutput = [\"SessionId\", \"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"SpeedMs\" and r._value > 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1d, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Top Speed ms\"}))\r\n  |> keep(columns:FinalOutput)\r\nNamedSeries |> yield()",
+          "refId": "Top Speed"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "hide": false,
+          "query": "import \"date\"\r\nFinalOutput = [\"SessionId\", \"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"SpeedMs\" and r._value > 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1d, fn: mean, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Avg Speed ms\"}))\r\n  |> keep(columns:FinalOutput)\r\nNamedSeries |> yield()",
+          "refId": "AVG Speed"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "hide": false,
+          "query": "import \"date\"\r\nFinalOutput = [\"SessionId\", \"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Session_Position_Overall\" and r._value > 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1d, fn: min, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"P.Top\"}))\r\n  |> keep(columns:FinalOutput)\r\nNamedSeries |> yield()",
+          "refId": "Top"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "hide": false,
+          "query": "import \"date\"\r\nFinalOutput = [\"SessionId\", \"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Session_Position_Overall\" and r._value > 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1d, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"P.Low\"}))\r\n  |> keep(columns:FinalOutput)\r\nNamedSeries |> yield()",
+          "refId": "Low"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "hide": false,
+          "query": "import \"date\"\r\nFinalOutput = [\"SessionId\", \"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"FuelData_FuelLeft\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1d, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"MaxFuel\"}))\r\n  |> keep(columns:FinalOutput)\r\nNamedSeries |> yield()",
+          "refId": "FuelMax"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "hide": false,
+          "query": "import \"date\"\r\nFinalOutput = [\"SessionId\", \"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"FuelData_FuelLeft\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1d, fn: min, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"MinFuel\"}))\r\n  |> keep(columns:FinalOutput)\r\nNamedSeries |> yield()",
+          "refId": "FuelLeft"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "hide": false,
+          "query": "import \"date\"\r\nFinalOutput = [\"SessionId\", \"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Session_PlayerClassSessionBestLapTime\" and r._value >= 0)\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1d, fn: min, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Best Lap Time\"}))\r\n  |> keep(columns:FinalOutput)\r\nNamedSeries |> yield()",
+          "refId": "BestLap"
+        }
+      ],
+      "title": "Session Stats",
+      "transformations": [
+        {
+          "id": "joinByField",
+          "options": {
+            "byField": "Time",
+            "mode": "outer"
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Distance",
+            "binary": {
+              "left": "Total Laps",
+              "operator": "*",
+              "reducer": "sum",
+              "right": "Track_Length"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Avg/Max",
+            "binary": {
+              "left": "Avg Lap Time",
+              "operator": "-",
+              "reducer": "sum",
+              "right": "Max Lap Time"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "AVG/Best",
+            "binary": {
+              "left": "Avg Lap Time",
+              "operator": "-",
+              "reducer": "sum",
+              "right": "Best Lap Time"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Top(${Speed:text})",
+            "binary": {
+              "left": "Top Speed ms",
+              "operator": "*",
+              "reducer": "sum",
+              "right": "${Speed}"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Avg(${Speed:text})",
+            "binary": {
+              "left": "Avg Speed ms",
+              "operator": "*",
+              "reducer": "sum",
+              "right": "${Speed}"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Fuel Used",
+            "binary": {
+              "left": "MinFuel",
+              "operator": "-",
+              "reducer": "sum",
+              "right": "MaxFuel"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Fuel/Lap ",
+            "binary": {
+              "left": "Fuel Used",
+              "operator": "/",
+              "reducer": "sum",
+              "right": "Total Laps"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Avg Speed ms": true,
+              "MaxFuel": true,
+              "MinFuel": false,
+              "Time": true,
+              "Top Speed ms": true
+            },
+            "indexByName": {
+              "AVG/Best": 10,
+              "Avg Lap Time": 6,
+              "Avg Speed ms": 12,
+              "Avg/Max": 9,
+              "Best Lap Time": 7,
+              "Distance": 5,
+              "Fuel Used": 14,
+              "Fuel/Lap ": 15,
+              "Max Lap Time": 8,
+              "MaxFuel": 13,
+              "MinFuel": 16,
+              "P.Low": 3,
+              "P.Top": 2,
+              "Time": 0,
+              "Top Speed ms": 11,
+              "Total Laps": 1,
+              "Track_Length": 4
+            },
+            "renameByName": {
+              "Distance": "Odometer",
+              "MinFuel": "Fuel Left ",
+              "Total Laps": "Total",
+              "Track_Length": "Track"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "center",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": false,
+            "inspect": false,
+            "minWidth": 50
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Track Length"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "lengthm"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "CurrentLapTime"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "CarNumber"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 95
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "CountryCode"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 69
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "iRating"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 76
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Driver"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 144
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 11,
+        "x": 0,
+        "y": 9
+      },
+      "id": 58,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "frameIndex": 1,
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "10.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "query": "import \"influxdata/influxdb/schema\"\r\nfrom(bucket: \"racing\")\r\n  |> range(start: -1y, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> filter(fn: (r) => r[\"_field\"] =~ /^(Session_CarNumber|Session_iRating|Session_StrengthOfField)$/)\r\n  |> limit(n:1)\r\n  |> schema.fieldsAsCols() \r\n  |> drop(columns: [\"GameName\",  \"CarModel\", \"_time\", \"TrackCode\", \"SessionId\", \"_start\",\"_stop\", \"SessionTypeName\", \"_measurement\", \"host\", \"topic\", \"UserId\", \"user\" ])\r\n  |> group(columns: [])  \r\n\r\n \r\n  \r\n\r\n\r\n",
+          "refId": "A"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {
+              "CountryCode": 2,
+              "Driver": 1,
+              "Session_CarNumber": 0,
+              "Session_iRating": 4,
+              "Team": 3
+            },
+            "renameByName": {
+              "Duration": "Minutes",
+              "Session_CarNumber": "CarNumber",
+              "Session_StrengthOfField": "Strength Of Field",
+              "Session_iRating": "iRating",
+              "Track_Length": "Track Length",
+              "_time_max": "Stop",
+              "_time_min": "Start",
+              "_value": "Car Number",
+              "user": "User"
+            }
+          }
+        }
+      ],
+      "transparent": true,
+      "type": "table"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 12
+      },
+      "id": 11,
+      "panels": [],
+      "title": "Tyres Position Penalties",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "yellow",
+            "mode": "thresholds"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "area"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "dark-blue",
+                "value": null
+              },
+              {
+                "color": "dark-yellow",
+                "value": 70
+              },
+              {
+                "color": "dark-green",
+                "value": 80
+              },
+              {
+                "color": "dark-orange",
+                "value": 90
+              },
+              {
+                "color": "dark-red",
+                "value": 100
+              }
+            ]
+          },
+          "unit": "celsius"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "BrakeTemp"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "light-blue",
+                      "value": null
+                    },
+                    {
+                      "color": "light-green",
+                      "value": 350
+                    },
+                    {
+                      "color": "light-red",
+                      "value": 650
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "custom.scaleDistribution",
+                "value": {
+                  "type": "linear"
+                }
+              },
+              {
+                "id": "custom.thresholdsStyle",
+                "value": {
+                  "mode": "dashed"
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 5,
+        "x": 0,
+        "y": 13
+      },
+      "id": 41,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Brake",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "0"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Front_Left_BrakeTemp\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Brake\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "BrakeTemp",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_TyreData_Front_Left_BrakeTemp"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Core",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "0"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Front_Left_CenterTemp\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Tyre Core\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()\r\n ",
+          "refId": "TyreCore",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_TyreData_Front_Left_CenterTemp"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Front Left Temp",
+      "transformations": [],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "yellow",
+            "mode": "thresholds"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "area"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "dark-blue",
+                "value": null
+              },
+              {
+                "color": "dark-yellow",
+                "value": 70
+              },
+              {
+                "color": "dark-green",
+                "value": 80
+              },
+              {
+                "color": "dark-orange",
+                "value": 90
+              },
+              {
+                "color": "dark-red",
+                "value": 100
+              }
+            ]
+          },
+          "unit": "celsius"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "BrakeTemp"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "light-blue",
+                      "value": null
+                    },
+                    {
+                      "color": "light-green",
+                      "value": 350
+                    },
+                    {
+                      "color": "light-red",
+                      "value": 650
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "custom.scaleDistribution",
+                "value": {
+                  "type": "linear"
+                }
+              },
+              {
+                "id": "custom.thresholdsStyle",
+                "value": {
+                  "mode": "dashed"
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 5,
+        "x": 5,
+        "y": 13
+      },
+      "id": 36,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Core",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "0"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Front_Right_CenterTemp\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Tyre Core\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()\r\n ",
+          "refId": "TyreCore",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_TyreData_Front_Left_CenterTemp"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Brake",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "0"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Front_Right_BrakeTemp\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Brake\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "BrakeTemp",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_TyreData_Front_Left_BrakeTemp"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Front Right Temp",
+      "transformations": [],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-RdYlGr"
+          },
+          "decimals": 0,
+          "mappings": [],
+          "min": 1,
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 2,
+        "x": 10,
+        "y": 13
+      },
+      "id": 22,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "vertical",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {
+          "titleSize": 1
+        },
+        "textMode": "value"
+      },
+      "pluginVersion": "10.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Session_Position_Overall\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: last, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Position\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_Session_Position_Overall"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Position",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-RdYlGr"
+          },
+          "decimals": 0,
+          "mappings": [],
+          "min": 1,
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 2,
+        "x": 12,
+        "y": 13
+      },
+      "id": 24,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {
+          "titleSize": 1
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Session_NumCars_Overall\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: ${SessionLen}s, fn: last, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Opponents\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_Session_NumCars_Overall"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Opponents ",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "orange",
+            "mode": "thresholds"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "area"
+            }
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 26
+              },
+              {
+                "color": "semi-dark-red",
+                "value": 27
+              }
+            ]
+          },
+          "unit": "pressurepsi"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Tyre"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "text",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "hidden"
+              },
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                }
+              },
+              {
+                "id": "min",
+                "value": 0
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Wear"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "unit",
+                "value": "percent"
+              },
+              {
+                "id": "max"
+              },
+              {
+                "id": "custom.thresholdsStyle",
+                "value": {
+                  "mode": "dashed"
+                }
+              },
+              {
+                "id": "min"
+              },
+              {
+                "id": "custom.scaleDistribution",
+                "value": {
+                  "type": "linear"
+                }
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "thresholds"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "light-yellow",
+                      "value": 50
+                    },
+                    {
+                      "color": "semi-dark-orange",
+                      "value": 70
+                    },
+                    {
+                      "color": "semi-dark-red",
+                      "value": 80
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 90
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "x10"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "hidden"
+              },
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 5,
+        "x": 14,
+        "y": 13
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Tyre",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Front_Left_Pressure\" and r._value >= 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Tyre\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "TyrePressure",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_FrontLeftPressure"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Wear",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Front_Left_PercentWear\" and r._value >= 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n      \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Wear\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "TyreWear",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_FrontLeftPercentWear"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Front Left (PSI-Wear)",
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "x10",
+            "binary": {
+              "left": "Tyre",
+              "operator": "*",
+              "reducer": "sum",
+              "right": "10"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "PSI",
+            "binary": {
+              "left": "x10",
+              "operator": "/",
+              "reducer": "sum",
+              "right": "70.3070"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": false
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Tyre": true,
+              "x10": true
+            },
+            "indexByName": {},
+            "renameByName": {}
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "orange",
+            "mode": "thresholds"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "area"
+            }
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 26
+              },
+              {
+                "color": "semi-dark-red",
+                "value": 27
+              }
+            ]
+          },
+          "unit": "pressurepsi"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Tyre"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "text",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "hidden"
+              },
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": true
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Wear"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "unit",
+                "value": "percent"
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "#EAB839",
+                      "value": 60
+                    },
+                    {
+                      "color": "semi-dark-orange",
+                      "value": 70
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 90
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "max"
+              },
+              {
+                "id": "custom.thresholdsStyle",
+                "value": {
+                  "mode": "dashed"
+                }
+              },
+              {
+                "id": "min",
+                "value": 0
+              },
+              {
+                "id": "custom.scaleDistribution",
+                "value": {
+                  "type": "linear"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "x10"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "hidden"
+              },
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 5,
+        "x": 19,
+        "y": 13
+      },
+      "id": 42,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Tyre",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Front_Right_Pressure\"  and r._value >= 0)\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Tyre\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "TyrePressure",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_FrontLeftPressure"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Wear",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Front_Right_PercentWear\" and r._value >= 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n      \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Wear\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "TyreWear",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_FrontLeftPercentWear"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Front Right (PSI-Wear)",
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "x10",
+            "binary": {
+              "left": "Tyre",
+              "operator": "*",
+              "reducer": "sum",
+              "right": "10"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "PSI",
+            "binary": {
+              "left": "x10",
+              "operator": "/",
+              "reducer": "sum",
+              "right": "70.3070"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": false
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-RdYlGr"
+          },
+          "decimals": 0,
+          "mappings": [],
+          "min": -1,
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 2,
+        "x": 10,
+        "y": 17
+      },
+      "id": 23,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Penalties_CutTrackWarnings\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: ${SessionLen}s, fn: max, createEmpty: false)\r\n\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Cuts\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_CutTrackWarnings"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Cuts",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-RdYlGr"
+          },
+          "decimals": 0,
+          "mappings": [],
+          "min": -1,
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 2,
+        "x": 12,
+        "y": 17
+      },
+      "id": 45,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Penalties_Incidents\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: ${SessionLen}s, fn: max, createEmpty: false)\r\n\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Incidents\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_CutTrackWarnings"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Incidents",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "yellow",
+            "mode": "thresholds"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "area"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "dark-blue",
+                "value": null
+              },
+              {
+                "color": "dark-yellow",
+                "value": 70
+              },
+              {
+                "color": "dark-green",
+                "value": 80
+              },
+              {
+                "color": "dark-orange",
+                "value": 90
+              },
+              {
+                "color": "dark-red",
+                "value": 100
+              }
+            ]
+          },
+          "unit": "celsius"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "BrakeTemp"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "light-blue",
+                      "value": null
+                    },
+                    {
+                      "color": "light-green",
+                      "value": 350
+                    },
+                    {
+                      "color": "light-red",
+                      "value": 650
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "custom.scaleDistribution",
+                "value": {
+                  "type": "linear"
+                }
+              },
+              {
+                "id": "custom.thresholdsStyle",
+                "value": {
+                  "mode": "dashed"
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 5,
+        "x": 0,
+        "y": 18
+      },
+      "id": 39,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Core",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "0"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Rear_Left_CenterTemp\" and r._value >= 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Tyre Core\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()\r\n ",
+          "refId": "TyreCore",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_TyreData_Front_Left_CenterTemp"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Brake",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "0"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Rear_Left_BrakeTemp\" and r._value >=0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Brake\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "BrakeTemp",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_TyreData_Front_Left_BrakeTemp"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Rear Left Temp",
+      "transformations": [],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "yellow",
+            "mode": "thresholds"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "area"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "dark-blue",
+                "value": null
+              },
+              {
+                "color": "dark-yellow",
+                "value": 70
+              },
+              {
+                "color": "dark-green",
+                "value": 80
+              },
+              {
+                "color": "dark-orange",
+                "value": 90
+              },
+              {
+                "color": "dark-red",
+                "value": 100
+              }
+            ]
+          },
+          "unit": "celsius"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "BrakeTemp"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "light-blue",
+                      "value": null
+                    },
+                    {
+                      "color": "light-green",
+                      "value": 350
+                    },
+                    {
+                      "color": "light-red",
+                      "value": 650
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "custom.scaleDistribution",
+                "value": {
+                  "type": "linear"
+                }
+              },
+              {
+                "id": "custom.thresholdsStyle",
+                "value": {
+                  "mode": "dashed"
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 5,
+        "x": 5,
+        "y": 18
+      },
+      "id": 40,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Core",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "0"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Rear_Right_CenterTemp\" and r._value >= 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Tyre Core\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()\r\n ",
+          "refId": "TyreCore",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_TyreData_Front_Left_CenterTemp"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Brake",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "0"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Rear_Right_BrakeTemp\" and r._value >=0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Brake\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "BrakeTemp",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_TyreData_Front_Left_BrakeTemp"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Rear Right Temp",
+      "transformations": [],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "orange",
+            "mode": "thresholds"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "area"
+            }
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 26
+              },
+              {
+                "color": "semi-dark-red",
+                "value": 27
+              }
+            ]
+          },
+          "unit": "pressurepsi"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Tyre"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "text",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "hidden"
+              },
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": true
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Wear"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "unit",
+                "value": "percent"
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 60
+                    },
+                    {
+                      "color": "semi-dark-orange",
+                      "value": 70
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 90
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "max"
+              },
+              {
+                "id": "custom.thresholdsStyle",
+                "value": {
+                  "mode": "dashed"
+                }
+              },
+              {
+                "id": "min",
+                "value": 0
+              },
+              {
+                "id": "custom.scaleDistribution",
+                "value": {
+                  "type": "linear"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "x10"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "hidden"
+              },
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 5,
+        "x": 14,
+        "y": 18
+      },
+      "id": 43,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Tyre",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Rear_Left_Pressure\" and r._value >= 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Tyre\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "TyrePressure",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_FrontLeftPressure"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Wear",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Rear_Left_PercentWear\" and r._value >= 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n      \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Wear\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "TyreWear",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_FrontLeftPercentWear"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Rear Left (PSI-Wear)",
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "x10",
+            "binary": {
+              "left": "Tyre",
+              "operator": "*",
+              "reducer": "sum",
+              "right": "10"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "PSI",
+            "binary": {
+              "left": "x10",
+              "operator": "/",
+              "reducer": "sum",
+              "right": "70.3070"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": false
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "orange",
+            "mode": "thresholds"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "area"
+            }
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 26
+              },
+              {
+                "color": "semi-dark-red",
+                "value": 27
+              }
+            ]
+          },
+          "unit": "pressurepsi"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Tyre"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "text",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "hidden"
+              },
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": true
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Wear"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "unit",
+                "value": "percent"
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 60
+                    },
+                    {
+                      "color": "semi-dark-orange",
+                      "value": 70
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 90
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "max"
+              },
+              {
+                "id": "custom.thresholdsStyle",
+                "value": {
+                  "mode": "dashed"
+                }
+              },
+              {
+                "id": "min",
+                "value": 0
+              },
+              {
+                "id": "custom.scaleDistribution",
+                "value": {
+                  "type": "linear"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "x10"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "hidden"
+              },
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 5,
+        "x": 19,
+        "y": 18
+      },
+      "id": 44,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Tyre",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Rear_Right_Pressure\" and r._value >= 0)\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Tyre\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "TyrePressure",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_FrontLeftPressure"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Wear",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Rear_Right_PercentWear\"  and r._value >= 0)\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n      \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Wear\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "TyreWear",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_FrontLeftPercentWear"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Rear Right (PSI-Wear)",
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "x10",
+            "binary": {
+              "left": "Tyre",
+              "operator": "*",
+              "reducer": "sum",
+              "right": "10"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "PSI",
+            "binary": {
+              "left": "x10",
+              "operator": "/",
+              "reducer": "sum",
+              "right": "70.3070"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": false
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-RdYlGr"
+          },
+          "decimals": 0,
+          "mappings": [],
+          "min": -1,
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 2,
+        "x": 10,
+        "y": 20
+      },
+      "id": 46,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Penalties_Total\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: ${SessionLen}s, fn: max, createEmpty: false)\r\n\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Penalties\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_CutTrackWarnings"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Penalties",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.1
+              },
+              {
+                "color": "yellow",
+                "value": 0.25
+              },
+              {
+                "color": "#88bf69",
+                "value": 0.5
+              },
+              {
+                "color": "dark-green",
+                "value": 0.6
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 2,
+        "x": 12,
+        "y": 20
+      },
+      "id": 51,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^Fuel%$/",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "pluginVersion": "10.0.2",
+      "targets": [
+        {
+          "alias": "Tyre",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"FuelData_FuelCapacity\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"FuelCapacity\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "FuelCapacity",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_FrontLeftPressure"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Wear",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"FuelData_FuelLeft\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n      \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"FuelLeft\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "FuelLeft",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_FrontLeftPercentWear"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Fuel %",
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Fuel%",
+            "binary": {
+              "left": "FuelLeft",
+              "operator": "/",
+              "reducer": "sum",
+              "right": "FuelCapacity"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": true
+          }
+        }
+      ],
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 23
+      },
+      "id": 4,
+      "panels": [],
+      "title": "Time Speed Inputs",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "purple",
+            "mode": "fixed"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Lap time",
+            "axisPlacement": "left",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 51,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [
+            {
+              "options": {
+                "1": {
+                  "color": "green",
+                  "index": 0
+                },
+                "2": {
+                  "color": "purple",
+                  "index": 1
+                },
+                "3": {
+                  "color": "yellow",
+                  "index": 2
+                },
+                "4": {
+                  "color": "#a5f700",
+                  "index": 3
+                },
+                "5": {
+                  "color": "semi-dark-blue",
+                  "index": 4
+                },
+                "6": {
+                  "color": "#ba05f7",
+                  "index": 5
+                },
+                "7": {
+                  "color": "#0affb9",
+                  "index": 6
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "clocks"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "Lap"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "custom.axisLabel",
+                "value": "Laps Num"
+              },
+              {
+                "id": "unit",
+                "value": "none"
+              },
+              {
+                "id": "custom.scaleDistribution",
+                "value": {
+                  "type": "linear"
+                }
+              },
+              {
+                "id": "decimals",
+                "value": 0
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 2
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 10,
+        "x": 0,
+        "y": 24
+      },
+      "id": 18,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Last Lap",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"LapTimePrevious\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Lap Valid Time\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "LapTime",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_LapTimePrevious"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Lap",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"CurrentLap\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Lap #\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "Lap",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_CurrentLap"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Last Lap",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "#be60f2",
+            "mode": "fixed"
+          },
+          "decimals": 0,
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "light-red",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 10,
+        "y": 24
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "10.0.2",
+      "targets": [
+        {
+          "alias": "maxspeedms",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1m"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "0"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"SpeedMs\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1d, fn: max, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"maxspeedms\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_SpeedMs"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Top Speed",
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "${Speed:text}",
+            "binary": {
+              "left": "_value",
+              "operator": "*",
+              "reducer": "sum",
+              "right": "${Speed}"
+            },
+            "mode": "binary",
+            "reduce": {
+              "include": [
+                "mqtt_consumer.last"
+              ],
+              "reducer": "sum"
+            },
+            "replaceFields": true
+          }
+        }
+      ],
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "log": 2,
+              "type": "symlog"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "B"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Delta Behind"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "A"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Delta Front"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 10,
+        "x": 14,
+        "y": 24
+      },
+      "id": 20,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean"
+          ],
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Delta Front",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Session_Delta_Front\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Delta_Front\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_DeltaFront"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Delta Behind",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "0"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Session_Delta_Behind\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Delta_Behind\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_DeltaBehind"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Deltas",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "left",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SpeedMs"
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": true
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Sector"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "displayName",
+                "value": "Sector"
+              },
+              {
+                "id": "max",
+                "value": 3
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-yellow",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "PitLimitMs"
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": true
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Km/h"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-blue",
+                  "mode": "shades"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 29
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.4.7",
+      "targets": [
+        {
+          "alias": "maxspeedms",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"SpeedMs\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"SpeedMs\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "SpeedMs",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_SpeedMs"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Section",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"PitData_PitSpeedLimit\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"PitLimitMs\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "PitLimit",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_Sector"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "hide": false,
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Session_Sector\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Sector\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "Sector"
+        }
+      ],
+      "title": "Speed",
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "${Speed:text}",
+            "binary": {
+              "left": "SpeedMs",
+              "operator": "*",
+              "reducer": "sum",
+              "right": "${Speed}"
+            },
+            "mode": "binary",
+            "reduce": {
+              "include": [
+                "mqtt_consumer.last"
+              ],
+              "reducer": "sum"
+            },
+            "replaceFields": false
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Pit Limit",
+            "binary": {
+              "left": "PitLimitMs",
+              "operator": "*",
+              "reducer": "sum",
+              "right": "${Speed}"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        }
+      ],
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 2,
+            "gradientMode": "scheme",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "SteeringAngle"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "unit",
+                "value": "none"
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 22
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "super-light-orange",
+                  "mode": "fixed",
+                  "seriesBy": "min"
+                }
+              },
+              {
+                "id": "displayName",
+                "value": "SteeringAngle"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "Brake"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-red",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "displayName",
+                "value": "Brake"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "Throttle"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-green",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "displayName",
+                "value": "Throttle"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "Clutch"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Clutch"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 2
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "Handbrake"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Handbrake"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 35
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Brake",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "0"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Brake\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: last, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n  |> set(key: \"_field\", value: \"Brake\")\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Brake\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "Brake",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_Brake"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Throttle",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "0"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Throttle\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: last, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n  |> set(key: \"_field\", value: \"Throttle\")\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Throttle\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "Throttle",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_Throttle"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Steer",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "linear"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"SteeringAngle\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: last, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n  |> set(key: \"_field\", value: \"SteeringAngle\")\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"SteeringAngle\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "SteeringAngle",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_SteeringAngle"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Throttle",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "0"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Clutch\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: last, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n  |> set(key: \"_field\", value: \"Clutch\")\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Clutch\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "Clutch",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_Throttle"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Throttle",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "0"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Handbrake\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: last, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n  |> set(key: \"_field\", value: \"Handbrake\")\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Handbrake\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "Handbrake",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_Throttle"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Inputs",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 44
+      },
+      "id": 52,
+      "panels": [],
+      "title": "Engine Data ",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "series",
+            "axisLabel": "RPMs",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "Gear"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "displayName",
+                "value": "Gear"
+              },
+              {
+                "id": "custom.axisLabel",
+                "value": "Gears"
+              },
+              {
+                "id": "custom.lineInterpolation",
+                "value": "stepBefore"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "RPM"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "RPM"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "MaxRPM"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Max RPM"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 45
+      },
+      "id": 35,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"EngineData_EngineRpm\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n  |> set(key: \"_field\", value: \"EngineData_EngineRpm\")\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"EngineData_EngineRpm\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "RPM",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_Rpms"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Gear",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Gear\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: last, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n  |> set(key: \"_field\", value: \"Gear\")\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Gear\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "Gear",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_Gear"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Max",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"EngineData_MaxEngineRpm\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n  |> set(key: \"_field\", value: \"EngineData_MaxEngineRpm\")\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"EngineData_MaxEngineRpm\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "MaxRPM",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_EngineData_MaxEngineRpm"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Engine RPMs",
+      "transformations": [],
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds",
+            "seriesBy": "last"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "series",
+            "axisLabel": "%",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "area"
+            }
+          },
+          "decimals": 0,
+          "mappings": [],
+          "max": 1,
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "super-light-yellow"
+              },
+              {
+                "color": "light-blue",
+                "value": 0
+              },
+              {
+                "color": "dark-green",
+                "value": 0.55
+              },
+              {
+                "color": "dark-red",
+                "value": 0.9
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 51
+      },
+      "id": 47,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"EngineData_EngineRpm\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n  |> set(key: \"_field\", value: \"EngineData_EngineRpm\")\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"EngineData_EngineRpm\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "RPM",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_Rpms"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Max",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"EngineData_MaxEngineRpm\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n  |> set(key: \"_field\", value: \"EngineData_MaxEngineRpm\")\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"EngineData_MaxEngineRpm\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "MaxRPM",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_EngineData_MaxEngineRpm"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Engine RPM %",
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "%RPM",
+            "binary": {
+              "left": "_value 1",
+              "operator": "/",
+              "reducer": "sum",
+              "right": "_value 2"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": true
+          }
+        }
+      ],
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "yellow",
+            "mode": "thresholds"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "area"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "dark-blue"
+              },
+              {
+                "color": "dark-yellow",
+                "value": 70
+              },
+              {
+                "color": "dark-green",
+                "value": 80
+              },
+              {
+                "color": "dark-orange",
+                "value": 100
+              },
+              {
+                "color": "dark-red",
+                "value": 143
+              }
+            ]
+          },
+          "unit": "celsius"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "EngineOilTemp"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "blue"
+                    },
+                    {
+                      "color": "light-green",
+                      "value": 82
+                    },
+                    {
+                      "color": "orange",
+                      "value": 104
+                    },
+                    {
+                      "color": "red",
+                      "value": 140
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "custom.scaleDistribution",
+                "value": {
+                  "type": "linear"
+                }
+              },
+              {
+                "id": "custom.thresholdsStyle",
+                "value": {
+                  "mode": "dashed"
+                }
+              },
+              {
+                "id": "displayName",
+                "value": "Oil"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "WaterTemp"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Water"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 9,
+        "x": 0,
+        "y": 57
+      },
+      "id": 48,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Core",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "0"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"EngineData_EngineWaterTemp\" and r._value >=0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"EngineData_EngineWaterTemp\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()\r\n ",
+          "refId": "WaterTemp",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_TyreData_Front_Left_CenterTemp"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Brake",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "0"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"EngineData_EngineOilTemp\" and r._value >= 0)\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"EngineData_EngineOilTemp\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "EngineOilTemp",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_TyreData_Front_Left_BrakeTemp"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Engine Temps",
+      "transformations": [],
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "orange",
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red"
+              },
+              {
+                "color": "green",
+                "value": 26
+              },
+              {
+                "color": "semi-dark-red",
+                "value": 27
+              }
+            ]
+          },
+          "unit": "litre"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 9,
+        "y": 57
+      },
+      "id": 50,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Tyre",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"FuelData_FuelCapacity\" and r._value >= 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"FuelCapacity\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "FuelCapacity",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_FrontLeftPressure"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Wear",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"FuelData_FuelLeft\" and r._value >= 0)\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n      \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"FuelLeft\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "FuelLeft",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_FrontLeftPercentWear"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Fuel",
+      "transformations": [],
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "orange",
+            "mode": "continuous-YlBl"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red"
+              },
+              {
+                "color": "green",
+                "value": 26
+              },
+              {
+                "color": "semi-dark-red",
+                "value": 27
+              }
+            ]
+          },
+          "unit": "pressurepsi"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "Oil"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "continuous-GrYlRd"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 7,
+        "x": 17,
+        "y": 57
+      },
+      "id": 49,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Tyre",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"EngineData_EngineOilPressure\"and r._value >= 0)\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Oil\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "Oil",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_FrontLeftPressure"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Wear",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"FuelData_FuelPressure\" and r._value >= 0)\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n      \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Fuel\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "Fuel",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_FrontLeftPercentWear"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Engine PSI",
+      "transformations": [],
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 63
+      },
+      "id": 55,
+      "panels": [],
+      "title": "Weather Distance Flags",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 16,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "celsius"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "Rain"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "unit",
+                "value": "humidity"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 24,
+        "x": 0,
+        "y": 64
+      },
+      "id": 31,
+      "options": {
+        "legend": {
+          "calcs": [
+            "min",
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Ambient Temp",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Conditions_Temperature_Ambient\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Ambient\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "Ambient",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_AmbientTemperature"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Track Temp",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Conditions_Temperature_Track\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Track\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "Track",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_TrackTemperature"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "hide": false,
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Conditions_RainDensity\" and r._value > 0)\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Rain Density\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "Rain"
+        }
+      ],
+      "title": "Temperature Conditions",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed"
+          },
+          "custom": {
+            "axisCenteredZero": true,
+            "axisColorMode": "text",
+            "axisGridShow": true,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 2,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [
+            {
+              "options": {
+                "1": {
+                  "color": "dark-green",
+                  "index": 0,
+                  "text": "Green"
+                },
+                "2": {
+                  "color": "dark-yellow",
+                  "index": 1,
+                  "text": "Yellow"
+                },
+                "4": {
+                  "color": "dark-blue",
+                  "index": 2,
+                  "text": "Blue"
+                },
+                "5": {
+                  "color": "#fbfbfb",
+                  "index": 3,
+                  "text": "White"
+                },
+                "8": {
+                  "color": "#403f3f",
+                  "index": 4,
+                  "text": "Unknown/Finish"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "max": 1,
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Flag"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "hidden"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 68
+      },
+      "id": 33,
+      "options": {
+        "barRadius": 0,
+        "barWidth": 0.97,
+        "colorByField": "Flag",
+        "fullHighlight": true,
+        "groupWidth": 0.7,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "orientation": "vertical",
+        "showValue": "never",
+        "stacking": "percent",
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        },
+        "xField": "Time",
+        "xTickLabelMaxLength": 6,
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 100
+      },
+      "pluginVersion": "10.0.2",
+      "targets": [
+        {
+          "$$hashKey": "object:24",
+          "aggregation": "Last",
+          "alias": "Flag",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "decimals": 2,
+          "displayAliasType": "Warning / Critical",
+          "displayType": "Regular",
+          "displayValueWithAlias": "Never",
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Session_Flag\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value+1.0, _time:r._time, _field:\"Flag\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_Flag"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": [],
+          "units": "none",
+          "valueHandler": "Number Threshold"
+        }
+      ],
+      "title": "Flag",
+      "transformations": [],
+      "transparent": true,
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "orange",
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red"
+              },
+              {
+                "color": "green",
+                "value": 26
+              },
+              {
+                "color": "semi-dark-red",
+                "value": 27
+              }
+            ]
+          },
+          "unit": "lengthm"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "%"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "unit",
+                "value": "percentunit"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 68
+      },
+      "id": 56,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Tyre",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"DistanceRoundTrack\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Distance\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "Distance",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_FrontLeftPressure"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          },
+          "hide": false,
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Track_Length\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Track Length\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "Track_Length"
+        }
+      ],
+      "title": "Distance in Meters",
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "%",
+            "binary": {
+              "left": "Distance",
+              "operator": "/",
+              "reducer": "sum",
+              "right": "Track Length"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        }
+      ],
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 76
+      },
+      "id": 57,
+      "panels": [],
+      "title": "Work In Progress",
+      "type": "row"
     }
+  ],
+  "refresh": "",
+  "revision": 1,
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": "Km/h",
+          "value": "3.6"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Speed",
+        "multi": false,
+        "name": "Speed",
+        "options": [
+          {
+            "selected": true,
+            "text": "Km/h",
+            "value": "3.6"
+          },
+          {
+            "selected": false,
+            "text": "MPH",
+            "value": "2.236936292054"
+          }
+        ],
+        "query": "Km/h : 3.6 , MPH : 2.236936292054",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "e Grant",
+          "value": "e Grant"
+        },
+        "datasource": {
+          "type": "influxdb",
+          "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+        },
+        "definition": "from(bucket: \"racing\")\r\n  |> range(start: -1y, stop: now())\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"Gear\")\r\n  |> keep(columns: [\"user\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> first()\r\n  |> group(columns: [])\r\n  |> drop(columns: [\"_value\",\"_time\"])",
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "User",
+        "options": [],
+        "query": "from(bucket: \"racing\")\r\n  |> range(start: -1y, stop: now())\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"Gear\")\r\n  |> keep(columns: [\"user\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> first()\r\n  |> group(columns: [])\r\n  |> drop(columns: [\"_value\",\"_time\"])",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "1689452999",
+          "value": "1689452999"
+        },
+        "datasource": {
+          "type": "influxdb",
+          "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+        },
+        "definition": "from(bucket: \"racing\")\r\n  |> range(start: -1y, stop: now())\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"CurrentLapTime\" and r._value > 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> keep(columns: [\"SessionId\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> first()\r\n  |> group(columns: [])\r\n  |> drop(columns: [\"_value\",\"_time\"])",
+        "hide": 0,
+        "includeAll": false,
+        "label": "SessionId",
+        "multi": false,
+        "name": "SessionId",
+        "options": [],
+        "query": "from(bucket: \"racing\")\r\n  |> range(start: -1y, stop: now())\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"CurrentLapTime\" and r._value > 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> keep(columns: [\"SessionId\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> first()\r\n  |> group(columns: [])\r\n  |> drop(columns: [\"_value\",\"_time\"])",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 3,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "1689431400549320400",
+          "value": "1689431400549320400"
+        },
+        "datasource": {
+          "type": "influxdb",
+          "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+        },
+        "definition": "data = from(bucket: \"racing\")\r\n  |> range(start:-1y, stop: now())\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"CurrentLapTime\" and r._value >= 0)\r\n\r\nStart = data\r\n  |> first(column: \"_time\")\r\n  |> map(fn: (r) => ({r with Start: int(v: r._time)}))\r\n  |> group()  \r\n  |> keep(columns: [\"Start\"])\r\n  |> yield()",
+        "hide": 2,
+        "includeAll": false,
+        "multi": false,
+        "name": "SessionStart",
+        "options": [],
+        "query": "data = from(bucket: \"racing\")\r\n  |> range(start:-1y, stop: now())\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"CurrentLapTime\" and r._value >= 0)\r\n\r\nStart = data\r\n  |> first(column: \"_time\")\r\n  |> map(fn: (r) => ({r with Start: int(v: r._time)}))\r\n  |> group()  \r\n  |> keep(columns: [\"Start\"])\r\n  |> yield()",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "1689432000422696200",
+          "value": "1689432000422696200"
+        },
+        "datasource": {
+          "type": "influxdb",
+          "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+        },
+        "definition": "data = from(bucket: \"racing\")\r\n  |> range(start:-1y, stop: now())\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"CurrentLapTime\" and r._value >= 0)\r\n\r\nStop = data\r\n  |> last(column: \"_time\")\r\n  |> map(fn: (r) => ({r with Stop: int(v: r._time)}))\r\n  |> group()  \r\n  |> keep(columns: [\"Stop\"])\r\n  |> yield()\r\n",
+        "hide": 2,
+        "includeAll": false,
+        "multi": false,
+        "name": "SessionEnd",
+        "options": [],
+        "query": "data = from(bucket: \"racing\")\r\n  |> range(start:-1y, stop: now())\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"CurrentLapTime\" and r._value >= 0)\r\n\r\nStop = data\r\n  |> last(column: \"_time\")\r\n  |> map(fn: (r) => ({r with Stop: int(v: r._time)}))\r\n  |> group()  \r\n  |> keep(columns: [\"Stop\"])\r\n  |> yield()\r\n",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "600",
+          "value": "600"
+        },
+        "datasource": {
+          "type": "influxdb",
+          "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+        },
+        "definition": "import \"date\"\r\nimport \"math\"\r\ndata = from(bucket: \"racing\")\r\n  |> range(start:-1y, stop: now())\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"CurrentLapTime\" and r._value >= 0)\r\nStop = data\r\n  |> last(column: \"_time\")\r\nStart = data\r\n  |> first(column: \"_time\")\r\njoin(tables: {min: Start, max: Stop}, on: [\"SessionId\"], method: \"inner\")\r\n  |> group()  \r\n  |> map(fn: (r) => ({r with Duration: math.round(x: (float(v: int(v: duration(v: uint(v: r._time_max) - uint(v: r._time_min))))/60000000000.0)*60.0)}))\r\n  |> keep(columns: [\"Duration\"])\r\n  |> yield()  ",
+        "hide": 2,
+        "includeAll": false,
+        "multi": false,
+        "name": "SessionLen",
+        "options": [],
+        "query": "import \"date\"\r\nimport \"math\"\r\ndata = from(bucket: \"racing\")\r\n  |> range(start:-1y, stop: now())\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"CurrentLapTime\" and r._value >= 0)\r\nStop = data\r\n  |> last(column: \"_time\")\r\nStart = data\r\n  |> first(column: \"_time\")\r\njoin(tables: {min: Start, max: Stop}, on: [\"SessionId\"], method: \"inner\")\r\n  |> group()  \r\n  |> map(fn: (r) => ({r with Duration: math.round(x: (float(v: int(v: duration(v: uint(v: r._time_max) - uint(v: r._time_min))))/60000000000.0)*60.0)}))\r\n  |> keep(columns: [\"Duration\"])\r\n  |> yield()  ",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "utc",
+  "title": "B4mad Session Details",
+  "uid": "e12c7ccb-ff51-4525-b5da-0d783a1019ef",
+  "version": 93,
+  "weekStart": ""
+}


### PR DESCRIPTION
Lots of changes 
-First all panels will query only the date range of the session and if most of their values are > 0 -Add table for session details with some process data  -remove limit to 0 in panel temp and psi
-change the thresholds of wear (was using the same as psi) -add pitlimit on the speed panel
-lower the fill of inputs panel 
-change Engine PSI thresholds because was using the same as Type  -Add Rain (but i haven't seem shown on cc data)
-Flags Data mapping (WIP)
-more that i don't remember