### PR TITLE
Update details-extended.yaml

### DIFF
--- a/manifests/base/grafana-v5/dashboards/details-extended.yaml
+++ b/manifests/base/grafana-v5/dashboards/details-extended.yaml
@@ -11,6021 +11,7112 @@ spec:
       datasourceName: "Racing"
   folder: CrewChief
   # resyncPeriod: 30s
-  json: >
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 31,
+  "links": [],
+  "liveNow": false,
+  "panels": [
     {
-      "annotations": {
-        "list": [
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 53,
+      "panels": [],
+      "title": "Session ${SessionId} for ${User} details",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_RACING}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "center",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false,
+            "minWidth": 50
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
           {
-            "builtIn": 1,
-            "datasource": {
-              "type": "grafana",
-              "uid": "-- Grafana --"
+            "matcher": {
+              "id": "byName",
+              "options": "Duration"
             },
-            "enable": true,
-            "hide": true,
-            "iconColor": "rgba(0, 211, 255, 1)",
-            "name": "Annotations & Alerts",
-            "target": {
-              "limit": 100,
-              "matchAny": false,
-              "tags": [],
-              "type": "dashboard"
+            "properties": [
+              {
+                "id": "unit",
+                "value": "m"
+              },
+              {
+                "id": "custom.width",
+                "value": 124
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Game"
             },
-            "type": "dashboard"
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 209
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Session Type"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 110
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Duration"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "clockms"
+              },
+              {
+                "id": "decimals",
+                "value": 2
+              },
+              {
+                "id": "custom.width",
+                "value": 200
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Track"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 204
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Stop"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 167
+              },
+              {
+                "id": "unit",
+                "value": "dateTimeFromNow"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Start"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 154
+              },
+              {
+                "id": "unit",
+                "value": "dateTimeFromNow"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Car Model"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 153
+              }
+            ]
           }
         ]
       },
-      "editable": true,
-      "fiscalYearStartMonth": 0,
-      "graphTooltip": 0,
-      "id": 31,
-      "links": [],
-      "liveNow": true,
-      "panels": [
-        {
-          "collapsed": false,
-          "gridPos": {
-            "h": 1,
-            "w": 24,
-            "x": 0,
-            "y": 0
-          },
-          "id": 53,
-          "panels": [],
-          "title": "Session ${SessionId} for ${User} details",
-          "type": "row"
+      "gridPos": {
+        "h": 4,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 54,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
         },
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "10.0.2",
+      "targets": [
         {
           "datasource": {
             "type": "influxdb",
             "uid": "${DS_RACING}"
           },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "custom": {
-                "align": "center",
-                "cellOptions": {
-                  "type": "auto"
-                },
-                "inspect": false,
-                "minWidth": 50
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Duration"
-                },
-                "properties": [
-                  {
-                    "id": "unit",
-                    "value": "m"
-                  }
-                ]
-              }
-            ]
-          },
-          "gridPos": {
-            "h": 3,
-            "w": 19,
-            "x": 0,
-            "y": 1
-          },
-          "id": 54,
-          "options": {
-            "cellHeight": "sm",
-            "footer": {
-              "countRows": false,
-              "fields": "",
-              "reducer": [
-                "sum"
-              ],
-              "show": false
-            },
-            "showHeader": true
-          },
-          "pluginVersion": "10.0.1",
-          "targets": [
-            {
-              "datasource": {
-                "type": "influxdb",
-                "uid": "${DS_RACING}"
-              },
-              "query": "fields = [\"_time\", \"GameName\", \"user\", \"CarModel\", \"TrackCode\", \"SessionId\", \"SessionType\"]\r\njfields = [\"GameName\", \"user\", \"CarModel\", \"TrackCode\", \"SessionId\", \"SessionType\"]\r\n\r\ndata = from(bucket: \"racing\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"CurrentLapTime\")\r\n  |> keep(columns: fields)\r\n\r\nmin = data\r\n  |> first(column: \"_time\")\r\n\r\nmax = data\r\n  |> last(column: \"_time\")\r\n\r\njoin(tables: {min: min, max: max}, on: jfields, method: \"inner\")\r\n  |> group()  \r\n  |> map(fn: (r) => ({r with Duration: float(v: int(v: duration(v: uint(v: r._time_max) - uint(v: r._time_min))))/60000000000.0}))\r\n  |> drop(columns: [\"SessionId\",  \"user\" ])\r\n  |> yield()",
-              "refId": "A"
-            }
-          ],
-          "transformations": [
-            {
-              "id": "organize",
-              "options": {
-                "excludeByName": {},
-                "indexByName": {
-                  "CarModel": 4,
-                  "Duration": 3,
-                  "GameName": 5,
-                  "SessionId": 8,
-                  "SessionType": 7,
-                  "TrackCode": 6,
-                  "_time_max": 2,
-                  "_time_min": 1,
-                  "user": 0
-                },
-                "renameByName": {
-                  "Duration": "",
-                  "_time_max": "Stop",
-                  "_time_min": "Start",
-                  "user": "User"
-                }
-              }
-            }
-          ],
-          "transparent": true,
-          "type": "table"
-        },
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "custom": {
-                "align": "center",
-                "cellOptions": {
-                  "type": "auto"
-                },
-                "filterable": false,
-                "inspect": false,
-                "minWidth": 50
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 3,
-            "w": 16,
-            "x": 0,
-            "y": 4
-          },
-          "id": 58,
-          "options": {
-            "cellHeight": "sm",
-            "footer": {
-              "countRows": false,
-              "fields": "",
-              "reducer": [
-                "sum"
-              ],
-              "show": false
-            },
-            "frameIndex": 1,
-            "showHeader": true,
-            "sortBy": [
-              {
-                "desc": false,
-                "displayName": "Strength Of Field"
-              }
-            ]
-          },
-          "pluginVersion": "10.0.1",
-          "targets": [
-            {
-              "datasource": {
-                "type": "influxdb",
-                "uid": "${DS_RACING}"
-              },
-              "query": "import \"influxdata/influxdb/schema\"\r\nfrom(bucket: \"racing\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> limit(n:1)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> filter(fn: (r) => r[\"_field\"] =~ /^(Session_CarNumber|Session_iRating|Session_StrengthOfField|Track_Length)$/)\r\n  |> schema.fieldsAsCols() \r\n  |> drop(columns: [\"GameName\",  \"CarModel\", \"TrackCode\", \"SessionId\", \"_time\", \"_start\",\"_stop\", \"SessionType\", \"_measurement\", \"host\", \"topic\", \"UserId\", \"user\" ])\r\n  |> group(columns: [])\r\n  |> limit(n:1)\r\n\r\n",
-              "refId": "A"
-            }
-          ],
-          "transformations": [
-            {
-              "id": "organize",
-              "options": {
-                "excludeByName": {},
-                "indexByName": {
-                  "CountryCode": 2,
-                  "Driver": 1,
-                  "Session_CarNumber": 0,
-                  "Session_iRating": 4,
-                  "Team": 3
-                },
-                "renameByName": {
-                  "Duration": "Minutes",
-                  "Session_CarNumber": "CarNumber",
-                  "Session_StrengthOfField": "Strength Of Field",
-                  "Session_iRating": "iRating",
-                  "Track_Length": "Track Length",
-                  "_time_max": "Stop",
-                  "_time_min": "Start",
-                  "_value": "Car Number",
-                  "user": "User"
-                }
-              }
-            }
-          ],
-          "transparent": true,
-          "type": "table"
-        },
-        {
-          "collapsed": false,
-          "gridPos": {
-            "h": 1,
-            "w": 24,
-            "x": 0,
-            "y": 7
-          },
-          "id": 11,
-          "panels": [],
-          "title": "Tyres Position Penalties",
-          "type": "row"
-        },
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "fixedColor": "yellow",
-                "mode": "thresholds"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 12,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 2,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "area"
-                }
-              },
-              "mappings": [],
-              "min": 0,
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "dark-blue",
-                    "value": null
-                  },
-                  {
-                    "color": "dark-yellow",
-                    "value": 70
-                  },
-                  {
-                    "color": "dark-green",
-                    "value": 80
-                  },
-                  {
-                    "color": "dark-orange",
-                    "value": 90
-                  },
-                  {
-                    "color": "dark-red",
-                    "value": 100
-                  }
-                ]
-              },
-              "unit": "celsius"
-            },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byFrameRefID",
-                  "options": "BrakeTemp"
-                },
-                "properties": [
-                  {
-                    "id": "custom.axisPlacement",
-                    "value": "right"
-                  },
-                  {
-                    "id": "thresholds",
-                    "value": {
-                      "mode": "absolute",
-                      "steps": [
-                        {
-                          "color": "light-blue",
-                          "value": null
-                        },
-                        {
-                          "color": "light-green",
-                          "value": 350
-                        },
-                        {
-                          "color": "light-red",
-                          "value": 650
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "id": "custom.scaleDistribution",
-                    "value": {
-                      "type": "linear"
-                    }
-                  },
-                  {
-                    "id": "custom.thresholdsStyle",
-                    "value": {
-                      "mode": "dashed"
-                    }
-                  }
-                ]
-              }
-            ]
-          },
-          "gridPos": {
-            "h": 5,
-            "w": 5,
-            "x": 0,
-            "y": 8
-          },
-          "id": 41,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "alias": "Core",
-              "datasource": {
-                "type": "influxdb",
-                "uid": "${DS_RACING}"
-              },
-              "groupBy": [
-                {
-                  "params": [
-                    "1s"
-                  ],
-                  "type": "time"
-                },
-                {
-                  "params": [
-                    "0"
-                  ],
-                  "type": "fill"
-                }
-              ],
-              "measurement": "mqtt_consumer",
-              "orderByTime": "ASC",
-              "policy": "default",
-              "query": "\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Front_Left_CenterTemp\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: v.windowPeriod, fn: max, createEmpty: false)\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Tyre Core\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()\r\n ",
-              "refId": "TyreCore",
-              "resultFormat": "time_series",
-              "select": [
-                [
-                  {
-                    "params": [
-                      "telemetry_TyreData_Front_Left_CenterTemp"
-                    ],
-                    "type": "field"
-                  },
-                  {
-                    "params": [],
-                    "type": "max"
-                  }
-                ]
-              ],
-              "tags": []
-            },
-            {
-              "alias": "Brake",
-              "datasource": {
-                "type": "influxdb",
-                "uid": "${DS_RACING}"
-              },
-              "groupBy": [
-                {
-                  "params": [
-                    "1s"
-                  ],
-                  "type": "time"
-                },
-                {
-                  "params": [
-                    "0"
-                  ],
-                  "type": "fill"
-                }
-              ],
-              "hide": false,
-              "measurement": "mqtt_consumer",
-              "orderByTime": "ASC",
-              "policy": "default",
-              "query": "FinalOutput = [\"_field\", \"_time\", \"_value\"]\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Front_Left_BrakeTemp\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: v.windowPeriod, fn: max, createEmpty: false)\r\n\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Brake\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-              "refId": "BrakeTemp",
-              "resultFormat": "time_series",
-              "select": [
-                [
-                  {
-                    "params": [
-                      "telemetry_TyreData_Front_Left_BrakeTemp"
-                    ],
-                    "type": "field"
-                  },
-                  {
-                    "params": [],
-                    "type": "max"
-                  }
-                ]
-              ],
-              "tags": []
-            }
-          ],
-          "title": "Front Left Temp",
-          "transformations": [],
-          "transparent": true,
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "fixedColor": "yellow",
-                "mode": "thresholds"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 12,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 2,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "area"
-                }
-              },
-              "mappings": [],
-              "min": 0,
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "dark-blue",
-                    "value": null
-                  },
-                  {
-                    "color": "dark-yellow",
-                    "value": 70
-                  },
-                  {
-                    "color": "dark-green",
-                    "value": 80
-                  },
-                  {
-                    "color": "dark-orange",
-                    "value": 90
-                  },
-                  {
-                    "color": "dark-red",
-                    "value": 100
-                  }
-                ]
-              },
-              "unit": "celsius"
-            },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byFrameRefID",
-                  "options": "BrakeTemp"
-                },
-                "properties": [
-                  {
-                    "id": "custom.axisPlacement",
-                    "value": "right"
-                  },
-                  {
-                    "id": "thresholds",
-                    "value": {
-                      "mode": "absolute",
-                      "steps": [
-                        {
-                          "color": "light-blue",
-                          "value": null
-                        },
-                        {
-                          "color": "light-green",
-                          "value": 350
-                        },
-                        {
-                          "color": "light-red",
-                          "value": 650
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "id": "custom.scaleDistribution",
-                    "value": {
-                      "type": "linear"
-                    }
-                  },
-                  {
-                    "id": "custom.thresholdsStyle",
-                    "value": {
-                      "mode": "dashed"
-                    }
-                  }
-                ]
-              }
-            ]
-          },
-          "gridPos": {
-            "h": 5,
-            "w": 5,
-            "x": 5,
-            "y": 8
-          },
-          "id": 36,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "alias": "Core",
-              "datasource": {
-                "type": "influxdb",
-                "uid": "${DS_RACING}"
-              },
-              "groupBy": [
-                {
-                  "params": [
-                    "1s"
-                  ],
-                  "type": "time"
-                },
-                {
-                  "params": [
-                    "0"
-                  ],
-                  "type": "fill"
-                }
-              ],
-              "measurement": "mqtt_consumer",
-              "orderByTime": "ASC",
-              "policy": "default",
-              "query": "\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Front_Right_CenterTemp\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: v.windowPeriod, fn: max, createEmpty: false)\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Tyre Core\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()\r\n ",
-              "refId": "TyreCore",
-              "resultFormat": "time_series",
-              "select": [
-                [
-                  {
-                    "params": [
-                      "telemetry_TyreData_Front_Left_CenterTemp"
-                    ],
-                    "type": "field"
-                  },
-                  {
-                    "params": [],
-                    "type": "max"
-                  }
-                ]
-              ],
-              "tags": []
-            },
-            {
-              "alias": "Brake",
-              "datasource": {
-                "type": "influxdb",
-                "uid": "${DS_RACING}"
-              },
-              "groupBy": [
-                {
-                  "params": [
-                    "1s"
-                  ],
-                  "type": "time"
-                },
-                {
-                  "params": [
-                    "0"
-                  ],
-                  "type": "fill"
-                }
-              ],
-              "hide": false,
-              "measurement": "mqtt_consumer",
-              "orderByTime": "ASC",
-              "policy": "default",
-              "query": "FinalOutput = [\"_field\", \"_time\", \"_value\"]\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Front_Right_BrakeTemp\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: v.windowPeriod, fn: max, createEmpty: false)\r\n\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Brake\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-              "refId": "BrakeTemp",
-              "resultFormat": "time_series",
-              "select": [
-                [
-                  {
-                    "params": [
-                      "telemetry_TyreData_Front_Left_BrakeTemp"
-                    ],
-                    "type": "field"
-                  },
-                  {
-                    "params": [],
-                    "type": "max"
-                  }
-                ]
-              ],
-              "tags": []
-            }
-          ],
-          "title": "Front Right Temp",
-          "transformations": [],
-          "transparent": true,
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "continuous-RdYlGr"
-              },
-              "decimals": 0,
-              "mappings": [],
-              "min": 1,
-              "noValue": "0",
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 4,
-            "w": 2,
-            "x": 10,
-            "y": 8
-          },
-          "id": 22,
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "center",
-            "orientation": "vertical",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "text": {
-              "titleSize": 1
-            },
-            "textMode": "value"
-          },
-          "pluginVersion": "10.0.1",
-          "targets": [
-            {
-              "datasource": {
-                "type": "influxdb",
-                "uid": "${DS_RACING}"
-              },
-              "groupBy": [
-                {
-                  "params": [
-                    "1s"
-                  ],
-                  "type": "time"
-                },
-                {
-                  "params": [
-                    "null"
-                  ],
-                  "type": "fill"
-                }
-              ],
-              "measurement": "mqtt_consumer",
-              "orderByTime": "ASC",
-              "policy": "default",
-              "query": "FinalOutput = [\"_field\", \"_time\", \"_value\"]\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Session_Position_Overall\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Position\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-              "refId": "A",
-              "resultFormat": "time_series",
-              "select": [
-                [
-                  {
-                    "params": [
-                      "telemetry_Session_Position_Overall"
-                    ],
-                    "type": "field"
-                  },
-                  {
-                    "params": [],
-                    "type": "last"
-                  }
-                ]
-              ],
-              "tags": []
-            }
-          ],
-          "title": "Position",
-          "transparent": true,
-          "type": "stat"
-        },
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "continuous-RdYlGr"
-              },
-              "decimals": 0,
-              "mappings": [],
-              "min": 1,
-              "noValue": "0",
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 4,
-            "w": 2,
-            "x": 12,
-            "y": 8
-          },
-          "id": 24,
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "center",
-            "orientation": "horizontal",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "text": {
-              "titleSize": 1
-            },
-            "textMode": "auto"
-          },
-          "pluginVersion": "10.0.1",
-          "targets": [
-            {
-              "datasource": {
-                "type": "influxdb",
-                "uid": "${DS_RACING}"
-              },
-              "groupBy": [
-                {
-                  "params": [
-                    "1s"
-                  ],
-                  "type": "time"
-                },
-                {
-                  "params": [
-                    "null"
-                  ],
-                  "type": "fill"
-                }
-              ],
-              "measurement": "mqtt_consumer",
-              "orderByTime": "ASC",
-              "policy": "default",
-              "query": "FinalOutput = [\"_field\", \"_time\", \"_value\"]\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Session_NumCars_Overall\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Opponents\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-              "refId": "A",
-              "resultFormat": "time_series",
-              "select": [
-                [
-                  {
-                    "params": [
-                      "telemetry_Session_NumCars_Overall"
-                    ],
-                    "type": "field"
-                  },
-                  {
-                    "params": [],
-                    "type": "last"
-                  }
-                ]
-              ],
-              "tags": []
-            }
-          ],
-          "title": "Opponents ",
-          "transparent": true,
-          "type": "stat"
-        },
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "fixedColor": "orange",
-                "mode": "thresholds"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 12,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 2,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "area"
-                }
-              },
-              "decimals": 2,
-              "mappings": [],
-              "min": 19,
-              "noValue": "0",
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "red",
-                    "value": null
-                  },
-                  {
-                    "color": "green",
-                    "value": 26
-                  },
-                  {
-                    "color": "semi-dark-red",
-                    "value": 27
-                  }
-                ]
-              },
-              "unit": "pressurepsi"
-            },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Tyre"
-                },
-                "properties": [
-                  {
-                    "id": "color",
-                    "value": {
-                      "fixedColor": "text",
-                      "mode": "fixed"
-                    }
-                  },
-                  {
-                    "id": "custom.axisPlacement",
-                    "value": "hidden"
-                  },
-                  {
-                    "id": "custom.hideFrom",
-                    "value": {
-                      "legend": true,
-                      "tooltip": true,
-                      "viz": true
-                    }
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Wear"
-                },
-                "properties": [
-                  {
-                    "id": "custom.axisPlacement",
-                    "value": "right"
-                  },
-                  {
-                    "id": "unit",
-                    "value": "percent"
-                  },
-                  {
-                    "id": "thresholds",
-                    "value": {
-                      "mode": "percentage",
-                      "steps": [
-                        {
-                          "color": "green",
-                          "value": null
-                        },
-                        {
-                          "color": "red",
-                          "value": 80
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "id": "max"
-                  },
-                  {
-                    "id": "custom.thresholdsStyle",
-                    "value": {
-                      "mode": "dashed"
-                    }
-                  },
-                  {
-                    "id": "min",
-                    "value": 0
-                  },
-                  {
-                    "id": "custom.scaleDistribution",
-                    "value": {
-                      "type": "linear"
-                    }
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "x10"
-                },
-                "properties": [
-                  {
-                    "id": "custom.axisPlacement",
-                    "value": "hidden"
-                  },
-                  {
-                    "id": "custom.hideFrom",
-                    "value": {
-                      "legend": true,
-                      "tooltip": true,
-                      "viz": true
-                    }
-                  }
-                ]
-              }
-            ]
-          },
-          "gridPos": {
-            "h": 5,
-            "w": 5,
-            "x": 14,
-            "y": 8
-          },
-          "id": 8,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "alias": "Tyre",
-              "datasource": {
-                "type": "influxdb",
-                "uid": "${DS_RACING}"
-              },
-              "groupBy": [
-                {
-                  "params": [
-                    "1s"
-                  ],
-                  "type": "time"
-                },
-                {
-                  "params": [
-                    "none"
-                  ],
-                  "type": "fill"
-                }
-              ],
-              "hide": false,
-              "measurement": "mqtt_consumer",
-              "orderByTime": "ASC",
-              "policy": "default",
-              "query": "FinalOutput = [\"_field\", \"_time\", \"_value\"]\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Front_Left_Pressure\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: v.windowPeriod, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Tyre\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-              "refId": "TyrePressure",
-              "resultFormat": "time_series",
-              "select": [
-                [
-                  {
-                    "params": [
-                      "telemetry_FrontLeftPressure"
-                    ],
-                    "type": "field"
-                  },
-                  {
-                    "params": [],
-                    "type": "max"
-                  }
-                ]
-              ],
-              "tags": []
-            },
-            {
-              "alias": "Wear",
-              "datasource": {
-                "type": "influxdb",
-                "uid": "${DS_RACING}"
-              },
-              "groupBy": [
-                {
-                  "params": [
-                    "1s"
-                  ],
-                  "type": "time"
-                },
-                {
-                  "params": [
-                    "none"
-                  ],
-                  "type": "fill"
-                }
-              ],
-              "hide": false,
-              "measurement": "mqtt_consumer",
-              "orderByTime": "ASC",
-              "policy": "default",
-              "query": "FinalOutput = [\"_field\", \"_time\", \"_value\"]\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Front_Left_PercentWear\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: v.windowPeriod, fn: max, createEmpty: false)\r\n      \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Wear\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-              "refId": "TyreWear",
-              "resultFormat": "time_series",
-              "select": [
-                [
-                  {
-                    "params": [
-                      "telemetry_FrontLeftPercentWear"
-                    ],
-                    "type": "field"
-                  },
-                  {
-                    "params": [],
-                    "type": "max"
-                  }
-                ]
-              ],
-              "tags": []
-            }
-          ],
-          "title": "Front Left (PSI-Wear)",
-          "transformations": [
-            {
-              "id": "calculateField",
-              "options": {
-                "alias": "x10",
-                "binary": {
-                  "left": "Tyre",
-                  "operator": "*",
-                  "reducer": "sum",
-                  "right": "10"
-                },
-                "mode": "binary",
-                "reduce": {
-                  "reducer": "sum"
-                }
-              }
-            },
-            {
-              "id": "calculateField",
-              "options": {
-                "alias": "PSI",
-                "binary": {
-                  "left": "x10",
-                  "operator": "/",
-                  "reducer": "sum",
-                  "right": "70.3070"
-                },
-                "mode": "binary",
-                "reduce": {
-                  "reducer": "sum"
-                },
-                "replaceFields": false
-              }
-            }
-          ],
-          "transparent": true,
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "fixedColor": "orange",
-                "mode": "thresholds"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 12,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 2,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "area"
-                }
-              },
-              "decimals": 2,
-              "mappings": [],
-              "min": 19,
-              "noValue": "0",
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "red",
-                    "value": null
-                  },
-                  {
-                    "color": "green",
-                    "value": 26
-                  },
-                  {
-                    "color": "semi-dark-red",
-                    "value": 27
-                  }
-                ]
-              },
-              "unit": "pressurepsi"
-            },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Tyre"
-                },
-                "properties": [
-                  {
-                    "id": "color",
-                    "value": {
-                      "fixedColor": "text",
-                      "mode": "fixed"
-                    }
-                  },
-                  {
-                    "id": "custom.axisPlacement",
-                    "value": "hidden"
-                  },
-                  {
-                    "id": "custom.hideFrom",
-                    "value": {
-                      "legend": true,
-                      "tooltip": true,
-                      "viz": true
-                    }
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Wear"
-                },
-                "properties": [
-                  {
-                    "id": "custom.axisPlacement",
-                    "value": "right"
-                  },
-                  {
-                    "id": "unit",
-                    "value": "percent"
-                  },
-                  {
-                    "id": "thresholds",
-                    "value": {
-                      "mode": "percentage",
-                      "steps": [
-                        {
-                          "color": "green",
-                          "value": null
-                        },
-                        {
-                          "color": "red",
-                          "value": 80
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "id": "max"
-                  },
-                  {
-                    "id": "custom.thresholdsStyle",
-                    "value": {
-                      "mode": "dashed"
-                    }
-                  },
-                  {
-                    "id": "min",
-                    "value": 0
-                  },
-                  {
-                    "id": "custom.scaleDistribution",
-                    "value": {
-                      "type": "linear"
-                    }
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "x10"
-                },
-                "properties": [
-                  {
-                    "id": "custom.axisPlacement",
-                    "value": "hidden"
-                  },
-                  {
-                    "id": "custom.hideFrom",
-                    "value": {
-                      "legend": true,
-                      "tooltip": true,
-                      "viz": true
-                    }
-                  }
-                ]
-              }
-            ]
-          },
-          "gridPos": {
-            "h": 5,
-            "w": 5,
-            "x": 19,
-            "y": 8
-          },
-          "id": 42,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "alias": "Tyre",
-              "datasource": {
-                "type": "influxdb",
-                "uid": "${DS_RACING}"
-              },
-              "groupBy": [
-                {
-                  "params": [
-                    "1s"
-                  ],
-                  "type": "time"
-                },
-                {
-                  "params": [
-                    "none"
-                  ],
-                  "type": "fill"
-                }
-              ],
-              "hide": false,
-              "measurement": "mqtt_consumer",
-              "orderByTime": "ASC",
-              "policy": "default",
-              "query": "FinalOutput = [\"_field\", \"_time\", \"_value\"]\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Front_Right_Pressure\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: v.windowPeriod, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Tyre\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-              "refId": "TyrePressure",
-              "resultFormat": "time_series",
-              "select": [
-                [
-                  {
-                    "params": [
-                      "telemetry_FrontLeftPressure"
-                    ],
-                    "type": "field"
-                  },
-                  {
-                    "params": [],
-                    "type": "max"
-                  }
-                ]
-              ],
-              "tags": []
-            },
-            {
-              "alias": "Wear",
-              "datasource": {
-                "type": "influxdb",
-                "uid": "${DS_RACING}"
-              },
-              "groupBy": [
-                {
-                  "params": [
-                    "1s"
-                  ],
-                  "type": "time"
-                },
-                {
-                  "params": [
-                    "none"
-                  ],
-                  "type": "fill"
-                }
-              ],
-              "hide": false,
-              "measurement": "mqtt_consumer",
-              "orderByTime": "ASC",
-              "policy": "default",
-              "query": "FinalOutput = [\"_field\", \"_time\", \"_value\"]\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Front_Right_PercentWear\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: v.windowPeriod, fn: max, createEmpty: false)\r\n      \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Wear\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-              "refId": "TyreWear",
-              "resultFormat": "time_series",
-              "select": [
-                [
-                  {
-                    "params": [
-                      "telemetry_FrontLeftPercentWear"
-                    ],
-                    "type": "field"
-                  },
-                  {
-                    "params": [],
-                    "type": "max"
-                  }
-                ]
-              ],
-              "tags": []
-            }
-          ],
-          "title": "Front Right (PSI-Wear)",
-          "transformations": [
-            {
-              "id": "calculateField",
-              "options": {
-                "alias": "x10",
-                "binary": {
-                  "left": "Tyre",
-                  "operator": "*",
-                  "reducer": "sum",
-                  "right": "10"
-                },
-                "mode": "binary",
-                "reduce": {
-                  "reducer": "sum"
-                }
-              }
-            },
-            {
-              "id": "calculateField",
-              "options": {
-                "alias": "PSI",
-                "binary": {
-                  "left": "x10",
-                  "operator": "/",
-                  "reducer": "sum",
-                  "right": "70.3070"
-                },
-                "mode": "binary",
-                "reduce": {
-                  "reducer": "sum"
-                },
-                "replaceFields": false
-              }
-            }
-          ],
-          "transparent": true,
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "continuous-RdYlGr"
-              },
-              "decimals": 0,
-              "mappings": [],
-              "min": -1,
-              "noValue": "0",
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 3,
-            "w": 2,
-            "x": 10,
-            "y": 12
-          },
-          "id": 23,
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "text": {},
-            "textMode": "auto"
-          },
-          "pluginVersion": "10.0.1",
-          "targets": [
-            {
-              "datasource": {
-                "type": "influxdb",
-                "uid": "${DS_RACING}"
-              },
-              "groupBy": [
-                {
-                  "params": [
-                    "1s"
-                  ],
-                  "type": "time"
-                },
-                {
-                  "params": [
-                    "null"
-                  ],
-                  "type": "fill"
-                }
-              ],
-              "measurement": "mqtt_consumer",
-              "orderByTime": "ASC",
-              "policy": "default",
-              "query": "FinalOutput = [\"_field\", \"_time\", \"_value\"]\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Penalties_CutTrackWarnings\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: v.windowPeriod, fn: max, createEmpty: false)\r\n\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Cuts\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-              "refId": "A",
-              "resultFormat": "time_series",
-              "select": [
-                [
-                  {
-                    "params": [
-                      "telemetry_CutTrackWarnings"
-                    ],
-                    "type": "field"
-                  },
-                  {
-                    "params": [],
-                    "type": "last"
-                  }
-                ]
-              ],
-              "tags": []
-            }
-          ],
-          "title": "Cuts",
-          "transparent": true,
-          "type": "stat"
-        },
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "continuous-RdYlGr"
-              },
-              "decimals": 0,
-              "mappings": [],
-              "min": -1,
-              "noValue": "0",
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 3,
-            "w": 2,
-            "x": 12,
-            "y": 12
-          },
-          "id": 45,
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "text": {},
-            "textMode": "auto"
-          },
-          "pluginVersion": "10.0.1",
-          "targets": [
-            {
-              "datasource": {
-                "type": "influxdb",
-                "uid": "${DS_RACING}"
-              },
-              "groupBy": [
-                {
-                  "params": [
-                    "1s"
-                  ],
-                  "type": "time"
-                },
-                {
-                  "params": [
-                    "null"
-                  ],
-                  "type": "fill"
-                }
-              ],
-              "measurement": "mqtt_consumer",
-              "orderByTime": "ASC",
-              "policy": "default",
-              "query": "FinalOutput = [\"_field\", \"_time\", \"_value\"]\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Penalties_Incidents\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: v.windowPeriod, fn: max, createEmpty: false)\r\n\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Incidents\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-              "refId": "A",
-              "resultFormat": "time_series",
-              "select": [
-                [
-                  {
-                    "params": [
-                      "telemetry_CutTrackWarnings"
-                    ],
-                    "type": "field"
-                  },
-                  {
-                    "params": [],
-                    "type": "last"
-                  }
-                ]
-              ],
-              "tags": []
-            }
-          ],
-          "title": "Incidents",
-          "transparent": true,
-          "type": "stat"
-        },
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "fixedColor": "yellow",
-                "mode": "thresholds"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 12,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 2,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "area"
-                }
-              },
-              "mappings": [],
-              "min": 0,
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "dark-blue",
-                    "value": null
-                  },
-                  {
-                    "color": "dark-yellow",
-                    "value": 70
-                  },
-                  {
-                    "color": "dark-green",
-                    "value": 80
-                  },
-                  {
-                    "color": "dark-orange",
-                    "value": 90
-                  },
-                  {
-                    "color": "dark-red",
-                    "value": 100
-                  }
-                ]
-              },
-              "unit": "celsius"
-            },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byFrameRefID",
-                  "options": "BrakeTemp"
-                },
-                "properties": [
-                  {
-                    "id": "custom.axisPlacement",
-                    "value": "right"
-                  },
-                  {
-                    "id": "thresholds",
-                    "value": {
-                      "mode": "absolute",
-                      "steps": [
-                        {
-                          "color": "light-blue",
-                          "value": null
-                        },
-                        {
-                          "color": "light-green",
-                          "value": 350
-                        },
-                        {
-                          "color": "light-red",
-                          "value": 650
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "id": "custom.scaleDistribution",
-                    "value": {
-                      "type": "linear"
-                    }
-                  },
-                  {
-                    "id": "custom.thresholdsStyle",
-                    "value": {
-                      "mode": "dashed"
-                    }
-                  }
-                ]
-              }
-            ]
-          },
-          "gridPos": {
-            "h": 5,
-            "w": 5,
-            "x": 0,
-            "y": 13
-          },
-          "id": 39,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "alias": "Core",
-              "datasource": {
-                "type": "influxdb",
-                "uid": "${DS_RACING}"
-              },
-              "groupBy": [
-                {
-                  "params": [
-                    "1s"
-                  ],
-                  "type": "time"
-                },
-                {
-                  "params": [
-                    "0"
-                  ],
-                  "type": "fill"
-                }
-              ],
-              "measurement": "mqtt_consumer",
-              "orderByTime": "ASC",
-              "policy": "default",
-              "query": "\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Rear_Left_CenterTemp\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: v.windowPeriod, fn: max, createEmpty: false)\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Tyre Core\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()\r\n ",
-              "refId": "TyreCore",
-              "resultFormat": "time_series",
-              "select": [
-                [
-                  {
-                    "params": [
-                      "telemetry_TyreData_Front_Left_CenterTemp"
-                    ],
-                    "type": "field"
-                  },
-                  {
-                    "params": [],
-                    "type": "max"
-                  }
-                ]
-              ],
-              "tags": []
-            },
-            {
-              "alias": "Brake",
-              "datasource": {
-                "type": "influxdb",
-                "uid": "${DS_RACING}"
-              },
-              "groupBy": [
-                {
-                  "params": [
-                    "1s"
-                  ],
-                  "type": "time"
-                },
-                {
-                  "params": [
-                    "0"
-                  ],
-                  "type": "fill"
-                }
-              ],
-              "hide": false,
-              "measurement": "mqtt_consumer",
-              "orderByTime": "ASC",
-              "policy": "default",
-              "query": "FinalOutput = [\"_field\", \"_time\", \"_value\"]\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Rear_Left_BrakeTemp\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: v.windowPeriod, fn: max, createEmpty: false)\r\n\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Brake\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-              "refId": "BrakeTemp",
-              "resultFormat": "time_series",
-              "select": [
-                [
-                  {
-                    "params": [
-                      "telemetry_TyreData_Front_Left_BrakeTemp"
-                    ],
-                    "type": "field"
-                  },
-                  {
-                    "params": [],
-                    "type": "max"
-                  }
-                ]
-              ],
-              "tags": []
-            }
-          ],
-          "title": "Rear Left Temp",
-          "transformations": [],
-          "transparent": true,
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "fixedColor": "yellow",
-                "mode": "thresholds"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 12,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 2,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "area"
-                }
-              },
-              "mappings": [],
-              "min": 0,
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "dark-blue",
-                    "value": null
-                  },
-                  {
-                    "color": "dark-yellow",
-                    "value": 70
-                  },
-                  {
-                    "color": "dark-green",
-                    "value": 80
-                  },
-                  {
-                    "color": "dark-orange",
-                    "value": 90
-                  },
-                  {
-                    "color": "dark-red",
-                    "value": 100
-                  }
-                ]
-              },
-              "unit": "celsius"
-            },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byFrameRefID",
-                  "options": "BrakeTemp"
-                },
-                "properties": [
-                  {
-                    "id": "custom.axisPlacement",
-                    "value": "right"
-                  },
-                  {
-                    "id": "thresholds",
-                    "value": {
-                      "mode": "absolute",
-                      "steps": [
-                        {
-                          "color": "light-blue",
-                          "value": null
-                        },
-                        {
-                          "color": "light-green",
-                          "value": 350
-                        },
-                        {
-                          "color": "light-red",
-                          "value": 650
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "id": "custom.scaleDistribution",
-                    "value": {
-                      "type": "linear"
-                    }
-                  },
-                  {
-                    "id": "custom.thresholdsStyle",
-                    "value": {
-                      "mode": "dashed"
-                    }
-                  }
-                ]
-              }
-            ]
-          },
-          "gridPos": {
-            "h": 5,
-            "w": 5,
-            "x": 5,
-            "y": 13
-          },
-          "id": 40,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "alias": "Core",
-              "datasource": {
-                "type": "influxdb",
-                "uid": "${DS_RACING}"
-              },
-              "groupBy": [
-                {
-                  "params": [
-                    "1s"
-                  ],
-                  "type": "time"
-                },
-                {
-                  "params": [
-                    "0"
-                  ],
-                  "type": "fill"
-                }
-              ],
-              "measurement": "mqtt_consumer",
-              "orderByTime": "ASC",
-              "policy": "default",
-              "query": "\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Rear_Right_CenterTemp\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: v.windowPeriod, fn: max, createEmpty: false)\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Tyre Core\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()\r\n ",
-              "refId": "TyreCore",
-              "resultFormat": "time_series",
-              "select": [
-                [
-                  {
-                    "params": [
-                      "telemetry_TyreData_Front_Left_CenterTemp"
-                    ],
-                    "type": "field"
-                  },
-                  {
-                    "params": [],
-                    "type": "max"
-                  }
-                ]
-              ],
-              "tags": []
-            },
-            {
-              "alias": "Brake",
-              "datasource": {
-                "type": "influxdb",
-                "uid": "${DS_RACING}"
-              },
-              "groupBy": [
-                {
-                  "params": [
-                    "1s"
-                  ],
-                  "type": "time"
-                },
-                {
-                  "params": [
-                    "0"
-                  ],
-                  "type": "fill"
-                }
-              ],
-              "hide": false,
-              "measurement": "mqtt_consumer",
-              "orderByTime": "ASC",
-              "policy": "default",
-              "query": "FinalOutput = [\"_field\", \"_time\", \"_value\"]\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Rear_Right_BrakeTemp\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: v.windowPeriod, fn: max, createEmpty: false)\r\n\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Brake\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-              "refId": "BrakeTemp",
-              "resultFormat": "time_series",
-              "select": [
-                [
-                  {
-                    "params": [
-                      "telemetry_TyreData_Front_Left_BrakeTemp"
-                    ],
-                    "type": "field"
-                  },
-                  {
-                    "params": [],
-                    "type": "max"
-                  }
-                ]
-              ],
-              "tags": []
-            }
-          ],
-          "title": "Rear Right Temp",
-          "transformations": [],
-          "transparent": true,
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "fixedColor": "orange",
-                "mode": "thresholds"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 12,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 2,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "area"
-                }
-              },
-              "decimals": 2,
-              "mappings": [],
-              "min": 19,
-              "noValue": "0",
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "red",
-                    "value": null
-                  },
-                  {
-                    "color": "green",
-                    "value": 26
-                  },
-                  {
-                    "color": "semi-dark-red",
-                    "value": 27
-                  }
-                ]
-              },
-              "unit": "pressurepsi"
-            },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Tyre"
-                },
-                "properties": [
-                  {
-                    "id": "color",
-                    "value": {
-                      "fixedColor": "text",
-                      "mode": "fixed"
-                    }
-                  },
-                  {
-                    "id": "custom.axisPlacement",
-                    "value": "hidden"
-                  },
-                  {
-                    "id": "custom.hideFrom",
-                    "value": {
-                      "legend": true,
-                      "tooltip": true,
-                      "viz": true
-                    }
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Wear"
-                },
-                "properties": [
-                  {
-                    "id": "custom.axisPlacement",
-                    "value": "right"
-                  },
-                  {
-                    "id": "unit",
-                    "value": "percent"
-                  },
-                  {
-                    "id": "thresholds",
-                    "value": {
-                      "mode": "percentage",
-                      "steps": [
-                        {
-                          "color": "green",
-                          "value": null
-                        },
-                        {
-                          "color": "red",
-                          "value": 80
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "id": "max"
-                  },
-                  {
-                    "id": "custom.thresholdsStyle",
-                    "value": {
-                      "mode": "dashed"
-                    }
-                  },
-                  {
-                    "id": "min",
-                    "value": 0
-                  },
-                  {
-                    "id": "custom.scaleDistribution",
-                    "value": {
-                      "type": "linear"
-                    }
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "x10"
-                },
-                "properties": [
-                  {
-                    "id": "custom.axisPlacement",
-                    "value": "hidden"
-                  },
-                  {
-                    "id": "custom.hideFrom",
-                    "value": {
-                      "legend": true,
-                      "tooltip": true,
-                      "viz": true
-                    }
-                  }
-                ]
-              }
-            ]
-          },
-          "gridPos": {
-            "h": 5,
-            "w": 5,
-            "x": 14,
-            "y": 13
-          },
-          "id": 43,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "alias": "Tyre",
-              "datasource": {
-                "type": "influxdb",
-                "uid": "${DS_RACING}"
-              },
-              "groupBy": [
-                {
-                  "params": [
-                    "1s"
-                  ],
-                  "type": "time"
-                },
-                {
-                  "params": [
-                    "none"
-                  ],
-                  "type": "fill"
-                }
-              ],
-              "hide": false,
-              "measurement": "mqtt_consumer",
-              "orderByTime": "ASC",
-              "policy": "default",
-              "query": "FinalOutput = [\"_field\", \"_time\", \"_value\"]\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Rear_Left_Pressure\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: v.windowPeriod, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Tyre\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-              "refId": "TyrePressure",
-              "resultFormat": "time_series",
-              "select": [
-                [
-                  {
-                    "params": [
-                      "telemetry_FrontLeftPressure"
-                    ],
-                    "type": "field"
-                  },
-                  {
-                    "params": [],
-                    "type": "max"
-                  }
-                ]
-              ],
-              "tags": []
-            },
-            {
-              "alias": "Wear",
-              "datasource": {
-                "type": "influxdb",
-                "uid": "${DS_RACING}"
-              },
-              "groupBy": [
-                {
-                  "params": [
-                    "1s"
-                  ],
-                  "type": "time"
-                },
-                {
-                  "params": [
-                    "none"
-                  ],
-                  "type": "fill"
-                }
-              ],
-              "hide": false,
-              "measurement": "mqtt_consumer",
-              "orderByTime": "ASC",
-              "policy": "default",
-              "query": "FinalOutput = [\"_field\", \"_time\", \"_value\"]\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Rear_Left_PercentWear\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: v.windowPeriod, fn: max, createEmpty: false)\r\n      \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Wear\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-              "refId": "TyreWear",
-              "resultFormat": "time_series",
-              "select": [
-                [
-                  {
-                    "params": [
-                      "telemetry_FrontLeftPercentWear"
-                    ],
-                    "type": "field"
-                  },
-                  {
-                    "params": [],
-                    "type": "max"
-                  }
-                ]
-              ],
-              "tags": []
-            }
-          ],
-          "title": "Rear Left (PSI-Wear)",
-          "transformations": [
-            {
-              "id": "calculateField",
-              "options": {
-                "alias": "x10",
-                "binary": {
-                  "left": "Tyre",
-                  "operator": "*",
-                  "reducer": "sum",
-                  "right": "10"
-                },
-                "mode": "binary",
-                "reduce": {
-                  "reducer": "sum"
-                }
-              }
-            },
-            {
-              "id": "calculateField",
-              "options": {
-                "alias": "PSI",
-                "binary": {
-                  "left": "x10",
-                  "operator": "/",
-                  "reducer": "sum",
-                  "right": "70.3070"
-                },
-                "mode": "binary",
-                "reduce": {
-                  "reducer": "sum"
-                },
-                "replaceFields": false
-              }
-            }
-          ],
-          "transparent": true,
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "fixedColor": "orange",
-                "mode": "thresholds"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 12,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 2,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "area"
-                }
-              },
-              "decimals": 2,
-              "mappings": [],
-              "min": 19,
-              "noValue": "0",
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "red",
-                    "value": null
-                  },
-                  {
-                    "color": "green",
-                    "value": 26
-                  },
-                  {
-                    "color": "semi-dark-red",
-                    "value": 27
-                  }
-                ]
-              },
-              "unit": "pressurepsi"
-            },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Tyre"
-                },
-                "properties": [
-                  {
-                    "id": "color",
-                    "value": {
-                      "fixedColor": "text",
-                      "mode": "fixed"
-                    }
-                  },
-                  {
-                    "id": "custom.axisPlacement",
-                    "value": "hidden"
-                  },
-                  {
-                    "id": "custom.hideFrom",
-                    "value": {
-                      "legend": true,
-                      "tooltip": true,
-                      "viz": true
-                    }
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Wear"
-                },
-                "properties": [
-                  {
-                    "id": "custom.axisPlacement",
-                    "value": "right"
-                  },
-                  {
-                    "id": "unit",
-                    "value": "percent"
-                  },
-                  {
-                    "id": "thresholds",
-                    "value": {
-                      "mode": "percentage",
-                      "steps": [
-                        {
-                          "color": "green",
-                          "value": null
-                        },
-                        {
-                          "color": "red",
-                          "value": 80
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "id": "max"
-                  },
-                  {
-                    "id": "custom.thresholdsStyle",
-                    "value": {
-                      "mode": "dashed"
-                    }
-                  },
-                  {
-                    "id": "min",
-                    "value": 0
-                  },
-                  {
-                    "id": "custom.scaleDistribution",
-                    "value": {
-                      "type": "linear"
-                    }
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "x10"
-                },
-                "properties": [
-                  {
-                    "id": "custom.axisPlacement",
-                    "value": "hidden"
-                  },
-                  {
-                    "id": "custom.hideFrom",
-                    "value": {
-                      "legend": true,
-                      "tooltip": true,
-                      "viz": true
-                    }
-                  }
-                ]
-              }
-            ]
-          },
-          "gridPos": {
-            "h": 5,
-            "w": 5,
-            "x": 19,
-            "y": 13
-          },
-          "id": 44,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "alias": "Tyre",
-              "datasource": {
-                "type": "influxdb",
-                "uid": "${DS_RACING}"
-              },
-              "groupBy": [
-                {
-                  "params": [
-                    "1s"
-                  ],
-                  "type": "time"
-                },
-                {
-                  "params": [
-                    "none"
-                  ],
-                  "type": "fill"
-                }
-              ],
-              "hide": false,
-              "measurement": "mqtt_consumer",
-              "orderByTime": "ASC",
-              "policy": "default",
-              "query": "FinalOutput = [\"_field\", \"_time\", \"_value\"]\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Rear_Right_Pressure\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: v.windowPeriod, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Tyre\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-              "refId": "TyrePressure",
-              "resultFormat": "time_series",
-              "select": [
-                [
-                  {
-                    "params": [
-                      "telemetry_FrontLeftPressure"
-                    ],
-                    "type": "field"
-                  },
-                  {
-                    "params": [],
-                    "type": "max"
-                  }
-                ]
-              ],
-              "tags": []
-            },
-            {
-              "alias": "Wear",
-              "datasource": {
-                "type": "influxdb",
-                "uid": "${DS_RACING}"
-              },
-              "groupBy": [
-                {
-                  "params": [
-                    "1s"
-                  ],
-                  "type": "time"
-                },
-                {
-                  "params": [
-                    "none"
-                  ],
-                  "type": "fill"
-                }
-              ],
-              "hide": false,
-              "measurement": "mqtt_consumer",
-              "orderByTime": "ASC",
-              "policy": "default",
-              "query": "FinalOutput = [\"_field\", \"_time\", \"_value\"]\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Rear_Right_PercentWear\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: v.windowPeriod, fn: max, createEmpty: false)\r\n      \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Wear\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-              "refId": "TyreWear",
-              "resultFormat": "time_series",
-              "select": [
-                [
-                  {
-                    "params": [
-                      "telemetry_FrontLeftPercentWear"
-                    ],
-                    "type": "field"
-                  },
-                  {
-                    "params": [],
-                    "type": "max"
-                  }
-                ]
-              ],
-              "tags": []
-            }
-          ],
-          "title": "Rear Right (PSI-Wear)",
-          "transformations": [
-            {
-              "id": "calculateField",
-              "options": {
-                "alias": "x10",
-                "binary": {
-                  "left": "Tyre",
-                  "operator": "*",
-                  "reducer": "sum",
-                  "right": "10"
-                },
-                "mode": "binary",
-                "reduce": {
-                  "reducer": "sum"
-                }
-              }
-            },
-            {
-              "id": "calculateField",
-              "options": {
-                "alias": "PSI",
-                "binary": {
-                  "left": "x10",
-                  "operator": "/",
-                  "reducer": "sum",
-                  "right": "70.3070"
-                },
-                "mode": "binary",
-                "reduce": {
-                  "reducer": "sum"
-                },
-                "replaceFields": false
-              }
-            }
-          ],
-          "transparent": true,
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "continuous-RdYlGr"
-              },
-              "decimals": 0,
-              "mappings": [],
-              "min": -1,
-              "noValue": "0",
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 3,
-            "w": 2,
-            "x": 10,
-            "y": 15
-          },
-          "id": 46,
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "text": {},
-            "textMode": "auto"
-          },
-          "pluginVersion": "10.0.1",
-          "targets": [
-            {
-              "datasource": {
-                "type": "influxdb",
-                "uid": "${DS_RACING}"
-              },
-              "groupBy": [
-                {
-                  "params": [
-                    "1s"
-                  ],
-                  "type": "time"
-                },
-                {
-                  "params": [
-                    "null"
-                  ],
-                  "type": "fill"
-                }
-              ],
-              "measurement": "mqtt_consumer",
-              "orderByTime": "ASC",
-              "policy": "default",
-              "query": "FinalOutput = [\"_field\", \"_time\", \"_value\"]\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Penalties_Total\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: v.windowPeriod, fn: max, createEmpty: false)\r\n\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Penalties\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-              "refId": "A",
-              "resultFormat": "time_series",
-              "select": [
-                [
-                  {
-                    "params": [
-                      "telemetry_CutTrackWarnings"
-                    ],
-                    "type": "field"
-                  },
-                  {
-                    "params": [],
-                    "type": "last"
-                  }
-                ]
-              ],
-              "tags": []
-            }
-          ],
-          "title": "Penalties",
-          "transparent": true,
-          "type": "stat"
-        },
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "decimals": 0,
-              "mappings": [],
-              "min": 0,
-              "noValue": "0",
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "red",
-                    "value": null
-                  },
-                  {
-                    "color": "orange",
-                    "value": 0.1
-                  },
-                  {
-                    "color": "yellow",
-                    "value": 0.25
-                  },
-                  {
-                    "color": "#88bf69",
-                    "value": 0.5
-                  },
-                  {
-                    "color": "dark-green",
-                    "value": 0.6
-                  }
-                ]
-              },
-              "unit": "percentunit"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 3,
-            "w": 2,
-            "x": 12,
-            "y": 15
-          },
-          "id": 51,
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "textMode": "auto"
-          },
-          "pluginVersion": "10.0.1",
-          "targets": [
-            {
-              "alias": "Tyre",
-              "datasource": {
-                "type": "influxdb",
-                "uid": "${DS_RACING}"
-              },
-              "groupBy": [
-                {
-                  "params": [
-                    "1s"
-                  ],
-                  "type": "time"
-                },
-                {
-                  "params": [
-                    "none"
-                  ],
-                  "type": "fill"
-                }
-              ],
-              "hide": false,
-              "measurement": "mqtt_consumer",
-              "orderByTime": "ASC",
-              "policy": "default",
-              "query": "FinalOutput = [\"_field\", \"_time\", \"_value\"]\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"FuelData_FuelCapacity\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: v.windowPeriod, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"FuelCapacity\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-              "refId": "FuelCapacity",
-              "resultFormat": "time_series",
-              "select": [
-                [
-                  {
-                    "params": [
-                      "telemetry_FrontLeftPressure"
-                    ],
-                    "type": "field"
-                  },
-                  {
-                    "params": [],
-                    "type": "max"
-                  }
-                ]
-              ],
-              "tags": []
-            },
-            {
-              "alias": "Wear",
-              "datasource": {
-                "type": "influxdb",
-                "uid": "${DS_RACING}"
-              },
-              "groupBy": [
-                {
-                  "params": [
-                    "1s"
-                  ],
-                  "type": "time"
-                },
-                {
-                  "params": [
-                    "none"
-                  ],
-                  "type": "fill"
-                }
-              ],
-              "hide": false,
-              "measurement": "mqtt_consumer",
-              "orderByTime": "ASC",
-              "policy": "default",
-              "query": "FinalOutput = [\"_field\", \"_time\", \"_value\"]\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"FuelData_FuelLeft\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: v.windowPeriod, fn: max, createEmpty: false)\r\n      \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"FuelLeft\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-              "refId": "FuelLeft",
-              "resultFormat": "time_series",
-              "select": [
-                [
-                  {
-                    "params": [
-                      "telemetry_FrontLeftPercentWear"
-                    ],
-                    "type": "field"
-                  },
-                  {
-                    "params": [],
-                    "type": "max"
-                  }
-                ]
-              ],
-              "tags": []
-            }
-          ],
-          "title": "Fuel %",
-          "transformations": [
-            {
-              "id": "calculateField",
-              "options": {
-                "alias": "Fuel%",
-                "binary": {
-                  "left": "FuelLeft",
-                  "operator": "/",
-                  "reducer": "sum",
-                  "right": "FuelCapacity"
-                },
-                "mode": "binary",
-                "reduce": {
-                  "reducer": "sum"
-                },
-                "replaceFields": true
-              }
-            }
-          ],
-          "transparent": true,
-          "type": "stat"
-        },
-        {
-          "collapsed": false,
-          "gridPos": {
-            "h": 1,
-            "w": 24,
-            "x": 0,
-            "y": 18
-          },
-          "id": 4,
-          "panels": [],
-          "title": "Time Speed Inputs",
-          "type": "row"
-        },
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "fixedColor": "purple",
-                "mode": "fixed"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "Lap time",
-                "axisPlacement": "left",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 51,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 2,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [
-                {
-                  "options": {
-                    "1": {
-                      "color": "green",
-                      "index": 0
-                    },
-                    "2": {
-                      "color": "purple",
-                      "index": 1
-                    },
-                    "3": {
-                      "color": "yellow",
-                      "index": 2
-                    },
-                    "4": {
-                      "color": "#a5f700",
-                      "index": 3
-                    },
-                    "5": {
-                      "color": "semi-dark-blue",
-                      "index": 4
-                    },
-                    "6": {
-                      "color": "#ba05f7",
-                      "index": 5
-                    },
-                    "7": {
-                      "color": "#0affb9",
-                      "index": 6
-                    }
-                  },
-                  "type": "value"
-                }
-              ],
-              "min": 0,
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  }
-                ]
-              },
-              "unit": "s"
-            },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byFrameRefID",
-                  "options": "B"
-                },
-                "properties": [
-                  {
-                    "id": "custom.axisPlacement",
-                    "value": "right"
-                  },
-                  {
-                    "id": "custom.axisLabel",
-                    "value": "Valid Laps"
-                  },
-                  {
-                    "id": "unit",
-                    "value": "none"
-                  },
-                  {
-                    "id": "custom.scaleDistribution",
-                    "value": {
-                      "type": "linear"
-                    }
-                  },
-                  {
-                    "id": "decimals",
-                    "value": 0
-                  }
-                ]
-              }
-            ]
-          },
-          "gridPos": {
-            "h": 5,
-            "w": 10,
-            "x": 0,
-            "y": 19
-          },
-          "id": 18,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": false
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "alias": "Last Lap",
-              "datasource": {
-                "type": "influxdb",
-                "uid": "${DS_RACING}"
-              },
-              "groupBy": [
-                {
-                  "params": [
-                    "1s"
-                  ],
-                  "type": "time"
-                },
-                {
-                  "params": [
-                    "null"
-                  ],
-                  "type": "fill"
-                }
-              ],
-              "measurement": "mqtt_consumer",
-              "orderByTime": "ASC",
-              "policy": "default",
-              "query": "FinalOutput = [\"_field\", \"_time\", \"_value\"]\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"LapTimePrevious\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: v.windowPeriod, fn: max, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Last Lap\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-              "refId": "A",
-              "resultFormat": "time_series",
-              "select": [
-                [
-                  {
-                    "params": [
-                      "telemetry_LapTimePrevious"
-                    ],
-                    "type": "field"
-                  },
-                  {
-                    "params": [],
-                    "type": "max"
-                  }
-                ]
-              ],
-              "tags": []
-            },
-            {
-              "alias": "Lap",
-              "datasource": {
-                "type": "influxdb",
-                "uid": "${DS_RACING}"
-              },
-              "groupBy": [
-                {
-                  "params": [
-                    "$__interval"
-                  ],
-                  "type": "time"
-                },
-                {
-                  "params": [
-                    "null"
-                  ],
-                  "type": "fill"
-                }
-              ],
-              "hide": false,
-              "measurement": "mqtt_consumer",
-              "orderByTime": "ASC",
-              "policy": "default",
-              "query": "\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"CurrentLap\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: v.windowPeriod, fn: max, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Lap\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-              "refId": "B",
-              "resultFormat": "time_series",
-              "select": [
-                [
-                  {
-                    "params": [
-                      "telemetry_CurrentLap"
-                    ],
-                    "type": "field"
-                  },
-                  {
-                    "params": [],
-                    "type": "mean"
-                  }
-                ]
-              ],
-              "tags": []
-            }
-          ],
-          "title": "Last Lap",
-          "transparent": true,
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "description": "",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "fixedColor": "#be60f2",
-                "mode": "fixed"
-              },
-              "decimals": 0,
-              "mappings": [],
-              "noValue": "0",
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "light-red",
-                    "value": null
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 5,
-            "w": 4,
-            "x": 10,
-            "y": 19
-          },
-          "id": 6,
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "center",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "textMode": "value_and_name"
-          },
-          "pluginVersion": "10.0.1",
-          "targets": [
-            {
-              "alias": "maxspeedms",
-              "datasource": {
-                "type": "influxdb",
-                "uid": "${DS_RACING}"
-              },
-              "groupBy": [
-                {
-                  "params": [
-                    "1m"
-                  ],
-                  "type": "time"
-                },
-                {
-                  "params": [
-                    "0"
-                  ],
-                  "type": "fill"
-                }
-              ],
-              "hide": false,
-              "measurement": "mqtt_consumer",
-              "orderByTime": "ASC",
-              "policy": "default",
-              "query": "FinalOutput = [\"_field\", \"_time\", \"_value\"]\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"SpeedMs\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1m, fn: max, createEmpty: true)\r\n  |> group(columns: [\"SessionId\"])\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"maxspeedms\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-              "refId": "A",
-              "resultFormat": "time_series",
-              "select": [
-                [
-                  {
-                    "params": [
-                      "telemetry_SpeedMs"
-                    ],
-                    "type": "field"
-                  },
-                  {
-                    "params": [],
-                    "type": "max"
-                  }
-                ]
-              ],
-              "tags": []
-            }
-          ],
-          "title": "Top Speed",
-          "transformations": [
-            {
-              "id": "calculateField",
-              "options": {
-                "alias": "${Speed:text}",
-                "binary": {
-                  "left": "_value",
-                  "operator": "*",
-                  "reducer": "sum",
-                  "right": "${Speed}"
-                },
-                "mode": "binary",
-                "reduce": {
-                  "include": [
-                    "mqtt_consumer.last"
-                  ],
-                  "reducer": "sum"
-                },
-                "replaceFields": true
-              }
-            }
-          ],
-          "transparent": true,
-          "type": "stat"
-        },
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "log": 2,
-                  "type": "symlog"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byFrameRefID",
-                  "options": "B"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Delta Behind"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byFrameRefID",
-                  "options": "A"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Delta Front"
-                  }
-                ]
-              }
-            ]
-          },
-          "gridPos": {
-            "h": 5,
-            "w": 10,
-            "x": 14,
-            "y": 19
-          },
-          "id": 20,
-          "options": {
-            "legend": {
-              "calcs": [
-                "mean"
-              ],
-              "displayMode": "list",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "alias": "Delta Front",
-              "datasource": {
-                "type": "influxdb",
-                "uid": "${DS_RACING}"
-              },
-              "groupBy": [
-                {
-                  "params": [
-                    "1s"
-                  ],
-                  "type": "time"
-                },
-                {
-                  "params": [
-                    "null"
-                  ],
-                  "type": "fill"
-                }
-              ],
-              "measurement": "mqtt_consumer",
-              "orderByTime": "ASC",
-              "policy": "default",
-              "query": "FinalOutput = [\"_field\", \"_time\", \"_value\"]\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Session_Delta_Front\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: v.windowPeriod, fn: max, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Delta_Front\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-              "refId": "A",
-              "resultFormat": "time_series",
-              "select": [
-                [
-                  {
-                    "params": [
-                      "telemetry_DeltaFront"
-                    ],
-                    "type": "field"
-                  },
-                  {
-                    "params": [],
-                    "type": "max"
-                  }
-                ]
-              ],
-              "tags": []
-            },
-            {
-              "alias": "Delta Behind",
-              "datasource": {
-                "type": "influxdb",
-                "uid": "${DS_RACING}"
-              },
-              "groupBy": [
-                {
-                  "params": [
-                    "1s"
-                  ],
-                  "type": "time"
-                },
-                {
-                  "params": [
-                    "0"
-                  ],
-                  "type": "fill"
-                }
-              ],
-              "hide": false,
-              "measurement": "mqtt_consumer",
-              "orderByTime": "ASC",
-              "policy": "default",
-              "query": "FinalOutput = [\"_field\", \"_time\", \"_value\"]\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Session_Delta_Behind\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: v.windowPeriod, fn: max, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Delta_Behind\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-              "refId": "B",
-              "resultFormat": "time_series",
-              "select": [
-                [
-                  {
-                    "params": [
-                      "telemetry_DeltaBehind"
-                    ],
-                    "type": "field"
-                  },
-                  {
-                    "params": [],
-                    "type": "max"
-                  }
-                ]
-              ],
-              "tags": []
-            }
-          ],
-          "title": "Deltas",
-          "transparent": true,
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "left",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "opacity",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "min": 0,
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "_value 1"
-                },
-                "properties": [
-                  {
-                    "id": "custom.hideFrom",
-                    "value": {
-                      "legend": true,
-                      "tooltip": true,
-                      "viz": true
-                    }
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "_value 2"
-                },
-                "properties": [
-                  {
-                    "id": "custom.axisPlacement",
-                    "value": "right"
-                  },
-                  {
-                    "id": "displayName",
-                    "value": "Sector"
-                  },
-                  {
-                    "id": "max",
-                    "value": 3
-                  }
-                ]
-              }
-            ]
-          },
-          "gridPos": {
-            "h": 6,
-            "w": 24,
-            "x": 0,
-            "y": 24
-          },
-          "id": 16,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "pluginVersion": "9.4.7",
-          "targets": [
-            {
-              "alias": "maxspeedms",
-              "datasource": {
-                "type": "influxdb",
-                "uid": "${DS_RACING}"
-              },
-              "groupBy": [
-                {
-                  "params": [
-                    "1s"
-                  ],
-                  "type": "time"
-                },
-                {
-                  "params": [
-                    "null"
-                  ],
-                  "type": "fill"
-                }
-              ],
-              "hide": false,
-              "measurement": "mqtt_consumer",
-              "orderByTime": "ASC",
-              "policy": "default",
-              "query": "FinalOutput = [\"_field\", \"_time\", \"_value\"]\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"SpeedMs\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"maxspeedms\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-              "refId": "A",
-              "resultFormat": "time_series",
-              "select": [
-                [
-                  {
-                    "params": [
-                      "telemetry_SpeedMs"
-                    ],
-                    "type": "field"
-                  },
-                  {
-                    "params": [],
-                    "type": "max"
-                  }
-                ]
-              ],
-              "tags": []
-            },
-            {
-              "alias": "Section",
-              "datasource": {
-                "type": "influxdb",
-                "uid": "${DS_RACING}"
-              },
-              "groupBy": [
-                {
-                  "params": [
-                    "1s"
-                  ],
-                  "type": "time"
-                },
-                {
-                  "params": [
-                    "null"
-                  ],
-                  "type": "fill"
-                }
-              ],
-              "hide": false,
-              "measurement": "mqtt_consumer",
-              "orderByTime": "ASC",
-              "policy": "default",
-              "query": "FinalOutput = [\"_field\", \"_time\", \"_value\"]\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Session_Sector\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Sector\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-              "refId": "B",
-              "resultFormat": "time_series",
-              "select": [
-                [
-                  {
-                    "params": [
-                      "telemetry_Sector"
-                    ],
-                    "type": "field"
-                  },
-                  {
-                    "params": [],
-                    "type": "max"
-                  }
-                ]
-              ],
-              "tags": []
-            }
-          ],
-          "title": "Speed",
-          "transformations": [
-            {
-              "id": "calculateField",
-              "options": {
-                "alias": "${Speed:text}",
-                "binary": {
-                  "left": "_value 1",
-                  "operator": "*",
-                  "reducer": "sum",
-                  "right": "${Speed}"
-                },
-                "mode": "binary",
-                "reduce": {
-                  "include": [
-                    "mqtt_consumer.last"
-                  ],
-                  "reducer": "sum"
-                },
-                "replaceFields": false
-              }
-            }
-          ],
-          "transparent": true,
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "description": "",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 28,
-                "gradientMode": "scheme",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 2,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "percentunit"
-            },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byFrameRefID",
-                  "options": "SteeringAngle"
-                },
-                "properties": [
-                  {
-                    "id": "custom.axisPlacement",
-                    "value": "right"
-                  },
-                  {
-                    "id": "unit",
-                    "value": "none"
-                  },
-                  {
-                    "id": "custom.fillOpacity",
-                    "value": 22
-                  },
-                  {
-                    "id": "color",
-                    "value": {
-                      "fixedColor": "super-light-orange",
-                      "mode": "fixed",
-                      "seriesBy": "min"
-                    }
-                  },
-                  {
-                    "id": "displayName",
-                    "value": "SteeringAngle"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byFrameRefID",
-                  "options": "Brake"
-                },
-                "properties": [
-                  {
-                    "id": "color",
-                    "value": {
-                      "fixedColor": "dark-red",
-                      "mode": "fixed"
-                    }
-                  },
-                  {
-                    "id": "displayName",
-                    "value": "Brake"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byFrameRefID",
-                  "options": "Throttle"
-                },
-                "properties": [
-                  {
-                    "id": "color",
-                    "value": {
-                      "fixedColor": "dark-green",
-                      "mode": "fixed"
-                    }
-                  },
-                  {
-                    "id": "displayName",
-                    "value": "Throttle"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byFrameRefID",
-                  "options": "Clutch"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Clutch"
-                  },
-                  {
-                    "id": "color",
-                    "value": {
-                      "fixedColor": "orange",
-                      "mode": "fixed"
-                    }
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byFrameRefID",
-                  "options": "Handbrake"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Handbrake"
-                  },
-                  {
-                    "id": "color",
-                    "value": {
-                      "fixedColor": "dark-blue",
-                      "mode": "fixed"
-                    }
-                  }
-                ]
-              }
-            ]
-          },
-          "gridPos": {
-            "h": 9,
-            "w": 24,
-            "x": 0,
-            "y": 30
-          },
-          "id": 2,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "alias": "Brake",
-              "datasource": {
-                "type": "influxdb",
-                "uid": "${DS_RACING}"
-              },
-              "groupBy": [
-                {
-                  "params": [
-                    "1s"
-                  ],
-                  "type": "time"
-                },
-                {
-                  "params": [
-                    "0"
-                  ],
-                  "type": "fill"
-                }
-              ],
-              "hide": false,
-              "measurement": "mqtt_consumer",
-              "orderByTime": "ASC",
-              "policy": "autogen",
-              "query": "FinalOutput = [\"_field\", \"_time\", \"_value\"]\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Brake\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n  |> set(key: \"_field\", value: \"Brake\")\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Brake\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-              "refId": "Brake",
-              "resultFormat": "time_series",
-              "select": [
-                [
-                  {
-                    "params": [
-                      "telemetry_Brake"
-                    ],
-                    "type": "field"
-                  },
-                  {
-                    "params": [],
-                    "type": "last"
-                  }
-                ]
-              ],
-              "tags": []
-            },
-            {
-              "alias": "Throttle",
-              "datasource": {
-                "type": "influxdb",
-                "uid": "${DS_RACING}"
-              },
-              "groupBy": [
-                {
-                  "params": [
-                    "1s"
-                  ],
-                  "type": "time"
-                },
-                {
-                  "params": [
-                    "0"
-                  ],
-                  "type": "fill"
-                }
-              ],
-              "hide": false,
-              "measurement": "mqtt_consumer",
-              "orderByTime": "ASC",
-              "policy": "autogen",
-              "query": "\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Throttle\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n  |> set(key: \"_field\", value: \"Throttle\")\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Throttle\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-              "refId": "Throttle",
-              "resultFormat": "time_series",
-              "select": [
-                [
-                  {
-                    "params": [
-                      "telemetry_Throttle"
-                    ],
-                    "type": "field"
-                  },
-                  {
-                    "params": [],
-                    "type": "last"
-                  }
-                ]
-              ],
-              "tags": []
-            },
-            {
-              "alias": "Steer",
-              "datasource": {
-                "type": "influxdb",
-                "uid": "${DS_RACING}"
-              },
-              "groupBy": [
-                {
-                  "params": [
-                    "1s"
-                  ],
-                  "type": "time"
-                },
-                {
-                  "params": [
-                    "linear"
-                  ],
-                  "type": "fill"
-                }
-              ],
-              "hide": false,
-              "measurement": "mqtt_consumer",
-              "orderByTime": "ASC",
-              "policy": "default",
-              "query": "FinalOutput = [\"_field\", \"_time\", \"_value\"]\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"SteeringAngle\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n  |> set(key: \"_field\", value: \"SteeringAngle\")\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"SteeringAngle\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-              "refId": "SteeringAngle",
-              "resultFormat": "time_series",
-              "select": [
-                [
-                  {
-                    "params": [
-                      "telemetry_SteeringAngle"
-                    ],
-                    "type": "field"
-                  },
-                  {
-                    "params": [],
-                    "type": "max"
-                  }
-                ]
-              ],
-              "tags": []
-            },
-            {
-              "alias": "Throttle",
-              "datasource": {
-                "type": "influxdb",
-                "uid": "${DS_RACING}"
-              },
-              "groupBy": [
-                {
-                  "params": [
-                    "1s"
-                  ],
-                  "type": "time"
-                },
-                {
-                  "params": [
-                    "0"
-                  ],
-                  "type": "fill"
-                }
-              ],
-              "hide": false,
-              "measurement": "mqtt_consumer",
-              "orderByTime": "ASC",
-              "policy": "autogen",
-              "query": "\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Clutch\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n  |> set(key: \"_field\", value: \"Clutch\")\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Clutch\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-              "refId": "Clutch",
-              "resultFormat": "time_series",
-              "select": [
-                [
-                  {
-                    "params": [
-                      "telemetry_Throttle"
-                    ],
-                    "type": "field"
-                  },
-                  {
-                    "params": [],
-                    "type": "last"
-                  }
-                ]
-              ],
-              "tags": []
-            },
-            {
-              "alias": "Throttle",
-              "datasource": {
-                "type": "influxdb",
-                "uid": "${DS_RACING}"
-              },
-              "groupBy": [
-                {
-                  "params": [
-                    "1s"
-                  ],
-                  "type": "time"
-                },
-                {
-                  "params": [
-                    "0"
-                  ],
-                  "type": "fill"
-                }
-              ],
-              "hide": false,
-              "measurement": "mqtt_consumer",
-              "orderByTime": "ASC",
-              "policy": "autogen",
-              "query": "\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Handbrake\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n  |> set(key: \"_field\", value: \"Handbrake\")\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Handbrake\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-              "refId": "Handbrake",
-              "resultFormat": "time_series",
-              "select": [
-                [
-                  {
-                    "params": [
-                      "telemetry_Throttle"
-                    ],
-                    "type": "field"
-                  },
-                  {
-                    "params": [],
-                    "type": "last"
-                  }
-                ]
-              ],
-              "tags": []
-            }
-          ],
-          "title": "Inputs",
-          "transparent": true,
-          "type": "timeseries"
-        },
-        {
-          "collapsed": false,
-          "gridPos": {
-            "h": 1,
-            "w": 24,
-            "x": 0,
-            "y": 39
-          },
-          "id": 52,
-          "panels": [],
-          "title": "Engine Data ",
-          "type": "row"
-        },
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "series",
-                "axisLabel": "RPMs",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "decimals": 0,
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byFrameRefID",
-                  "options": "Gear"
-                },
-                "properties": [
-                  {
-                    "id": "custom.axisPlacement",
-                    "value": "right"
-                  },
-                  {
-                    "id": "displayName",
-                    "value": "Gear"
-                  },
-                  {
-                    "id": "custom.axisLabel",
-                    "value": "Gears"
-                  },
-                  {
-                    "id": "custom.lineInterpolation",
-                    "value": "stepBefore"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byFrameRefID",
-                  "options": "RPM"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "RPM"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byFrameRefID",
-                  "options": "MaxRPM"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Max RPM"
-                  },
-                  {
-                    "id": "color",
-                    "value": {
-                      "fixedColor": "dark-red",
-                      "mode": "fixed"
-                    }
-                  }
-                ]
-              }
-            ]
-          },
-          "gridPos": {
-            "h": 6,
-            "w": 24,
-            "x": 0,
-            "y": 40
-          },
-          "id": 35,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "influxdb",
-                "uid": "${DS_RACING}"
-              },
-              "groupBy": [
-                {
-                  "params": [
-                    "1s"
-                  ],
-                  "type": "time"
-                },
-                {
-                  "params": [
-                    "none"
-                  ],
-                  "type": "fill"
-                }
-              ],
-              "measurement": "mqtt_consumer",
-              "orderByTime": "ASC",
-              "policy": "default",
-              "query": "\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"EngineData_EngineRpm\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n  |> set(key: \"_field\", value: \"EngineData_EngineRpm\")\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"EngineData_EngineRpm\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-              "refId": "RPM",
-              "resultFormat": "time_series",
-              "select": [
-                [
-                  {
-                    "params": [
-                      "telemetry_Rpms"
-                    ],
-                    "type": "field"
-                  },
-                  {
-                    "params": [],
-                    "type": "max"
-                  }
-                ]
-              ],
-              "tags": []
-            },
-            {
-              "alias": "Gear",
-              "datasource": {
-                "type": "influxdb",
-                "uid": "${DS_RACING}"
-              },
-              "groupBy": [
-                {
-                  "params": [
-                    "1s"
-                  ],
-                  "type": "time"
-                },
-                {
-                  "params": [
-                    "none"
-                  ],
-                  "type": "fill"
-                }
-              ],
-              "hide": false,
-              "measurement": "mqtt_consumer",
-              "orderByTime": "ASC",
-              "policy": "default",
-              "query": "FinalOutput = [\"_field\", \"_time\", \"_value\"]\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Gear\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: last, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n  |> set(key: \"_field\", value: \"Gear\")\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Gear\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-              "refId": "Gear",
-              "resultFormat": "time_series",
-              "select": [
-                [
-                  {
-                    "params": [
-                      "telemetry_Gear"
-                    ],
-                    "type": "field"
-                  },
-                  {
-                    "params": [],
-                    "type": "max"
-                  }
-                ]
-              ],
-              "tags": []
-            },
-            {
-              "alias": "Max",
-              "datasource": {
-                "type": "influxdb",
-                "uid": "${DS_RACING}"
-              },
-              "groupBy": [
-                {
-                  "params": [
-                    "1s"
-                  ],
-                  "type": "time"
-                },
-                {
-                  "params": [
-                    "none"
-                  ],
-                  "type": "fill"
-                }
-              ],
-              "hide": false,
-              "measurement": "mqtt_consumer",
-              "orderByTime": "ASC",
-              "policy": "default",
-              "query": "FinalOutput = [\"_field\", \"_time\", \"_value\"]\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"EngineData_MaxEngineRpm\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n  |> set(key: \"_field\", value: \"EngineData_MaxEngineRpm\")\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"EngineData_MaxEngineRpm\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-              "refId": "MaxRPM",
-              "resultFormat": "time_series",
-              "select": [
-                [
-                  {
-                    "params": [
-                      "telemetry_EngineData_MaxEngineRpm"
-                    ],
-                    "type": "field"
-                  },
-                  {
-                    "params": [],
-                    "type": "max"
-                  }
-                ]
-              ],
-              "tags": []
-            }
-          ],
-          "title": "Engine RPMs",
-          "transformations": [],
-          "transparent": true,
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds",
-                "seriesBy": "last"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "series",
-                "axisLabel": "%",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "area"
-                }
-              },
-              "decimals": 0,
-              "mappings": [],
-              "max": 1,
-              "noValue": "0",
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "super-light-yellow",
-                    "value": null
-                  },
-                  {
-                    "color": "light-blue",
-                    "value": 0
-                  },
-                  {
-                    "color": "dark-green",
-                    "value": 0.55
-                  },
-                  {
-                    "color": "dark-red",
-                    "value": 0.9
-                  }
-                ]
-              },
-              "unit": "percentunit"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 6,
-            "w": 24,
-            "x": 0,
-            "y": 46
-          },
-          "id": 47,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "influxdb",
-                "uid": "${DS_RACING}"
-              },
-              "groupBy": [
-                {
-                  "params": [
-                    "1s"
-                  ],
-                  "type": "time"
-                },
-                {
-                  "params": [
-                    "none"
-                  ],
-                  "type": "fill"
-                }
-              ],
-              "measurement": "mqtt_consumer",
-              "orderByTime": "ASC",
-              "policy": "default",
-              "query": "FinalOutput = [\"_field\", \"_time\", \"_value\"]\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"EngineData_EngineRpm\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n  |> set(key: \"_field\", value: \"EngineData_EngineRpm\")\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"EngineData_EngineRpm\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-              "refId": "RPM",
-              "resultFormat": "time_series",
-              "select": [
-                [
-                  {
-                    "params": [
-                      "telemetry_Rpms"
-                    ],
-                    "type": "field"
-                  },
-                  {
-                    "params": [],
-                    "type": "max"
-                  }
-                ]
-              ],
-              "tags": []
-            },
-            {
-              "alias": "Max",
-              "datasource": {
-                "type": "influxdb",
-                "uid": "${DS_RACING}"
-              },
-              "groupBy": [
-                {
-                  "params": [
-                    "1s"
-                  ],
-                  "type": "time"
-                },
-                {
-                  "params": [
-                    "none"
-                  ],
-                  "type": "fill"
-                }
-              ],
-              "hide": false,
-              "measurement": "mqtt_consumer",
-              "orderByTime": "ASC",
-              "policy": "default",
-              "query": "FinalOutput = [\"_field\", \"_time\", \"_value\"]\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"EngineData_MaxEngineRpm\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n  |> set(key: \"_field\", value: \"EngineData_MaxEngineRpm\")\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"EngineData_MaxEngineRpm\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-              "refId": "MaxRPM",
-              "resultFormat": "time_series",
-              "select": [
-                [
-                  {
-                    "params": [
-                      "telemetry_EngineData_MaxEngineRpm"
-                    ],
-                    "type": "field"
-                  },
-                  {
-                    "params": [],
-                    "type": "max"
-                  }
-                ]
-              ],
-              "tags": []
-            }
-          ],
-          "title": "Engine RPM %",
-          "transformations": [
-            {
-              "id": "calculateField",
-              "options": {
-                "alias": "%RPM",
-                "binary": {
-                  "left": "_value 1",
-                  "operator": "/",
-                  "reducer": "sum",
-                  "right": "_value 2"
-                },
-                "mode": "binary",
-                "reduce": {
-                  "reducer": "sum"
-                },
-                "replaceFields": true
-              }
-            }
-          ],
-          "transparent": true,
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "fixedColor": "yellow",
-                "mode": "thresholds"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 12,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 2,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "area"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "dark-blue",
-                    "value": null
-                  },
-                  {
-                    "color": "dark-yellow",
-                    "value": 70
-                  },
-                  {
-                    "color": "dark-green",
-                    "value": 80
-                  },
-                  {
-                    "color": "dark-orange",
-                    "value": 100
-                  },
-                  {
-                    "color": "dark-red",
-                    "value": 143
-                  }
-                ]
-              },
-              "unit": "celsius"
-            },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byFrameRefID",
-                  "options": "EngineOilTemp"
-                },
-                "properties": [
-                  {
-                    "id": "custom.axisPlacement",
-                    "value": "right"
-                  },
-                  {
-                    "id": "thresholds",
-                    "value": {
-                      "mode": "absolute",
-                      "steps": [
-                        {
-                          "color": "blue",
-                          "value": null
-                        },
-                        {
-                          "color": "light-green",
-                          "value": 82
-                        },
-                        {
-                          "color": "orange",
-                          "value": 104
-                        },
-                        {
-                          "color": "red",
-                          "value": 140
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "id": "custom.scaleDistribution",
-                    "value": {
-                      "type": "linear"
-                    }
-                  },
-                  {
-                    "id": "custom.thresholdsStyle",
-                    "value": {
-                      "mode": "dashed"
-                    }
-                  },
-                  {
-                    "id": "displayName",
-                    "value": "Oil"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byFrameRefID",
-                  "options": "WaterTemp"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Water"
-                  }
-                ]
-              }
-            ]
-          },
-          "gridPos": {
-            "h": 6,
-            "w": 9,
-            "x": 0,
-            "y": 52
-          },
-          "id": 48,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "alias": "Core",
-              "datasource": {
-                "type": "influxdb",
-                "uid": "${DS_RACING}"
-              },
-              "groupBy": [
-                {
-                  "params": [
-                    "1s"
-                  ],
-                  "type": "time"
-                },
-                {
-                  "params": [
-                    "0"
-                  ],
-                  "type": "fill"
-                }
-              ],
-              "measurement": "mqtt_consumer",
-              "orderByTime": "ASC",
-              "policy": "default",
-              "query": "\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"EngineData_EngineWaterTemp\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: v.windowPeriod, fn: max, createEmpty: false)\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"EngineData_EngineWaterTemp\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()\r\n ",
-              "refId": "WaterTemp",
-              "resultFormat": "time_series",
-              "select": [
-                [
-                  {
-                    "params": [
-                      "telemetry_TyreData_Front_Left_CenterTemp"
-                    ],
-                    "type": "field"
-                  },
-                  {
-                    "params": [],
-                    "type": "max"
-                  }
-                ]
-              ],
-              "tags": []
-            },
-            {
-              "alias": "Brake",
-              "datasource": {
-                "type": "influxdb",
-                "uid": "${DS_RACING}"
-              },
-              "groupBy": [
-                {
-                  "params": [
-                    "1s"
-                  ],
-                  "type": "time"
-                },
-                {
-                  "params": [
-                    "0"
-                  ],
-                  "type": "fill"
-                }
-              ],
-              "hide": false,
-              "measurement": "mqtt_consumer",
-              "orderByTime": "ASC",
-              "policy": "default",
-              "query": "FinalOutput = [\"_field\", \"_time\", \"_value\"]\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"EngineData_EngineOilTemp\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: v.windowPeriod, fn: max, createEmpty: false)\r\n\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"EngineData_EngineOilTemp\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-              "refId": "EngineOilTemp",
-              "resultFormat": "time_series",
-              "select": [
-                [
-                  {
-                    "params": [
-                      "telemetry_TyreData_Front_Left_BrakeTemp"
-                    ],
-                    "type": "field"
-                  },
-                  {
-                    "params": [],
-                    "type": "max"
-                  }
-                ]
-              ],
-              "tags": []
-            }
-          ],
-          "title": "Engine Temps",
-          "transformations": [],
-          "transparent": true,
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "fixedColor": "orange",
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 12,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 2,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "min": 0,
-              "noValue": "0",
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "red",
-                    "value": null
-                  },
-                  {
-                    "color": "green",
-                    "value": 26
-                  },
-                  {
-                    "color": "semi-dark-red",
-                    "value": 27
-                  }
-                ]
-              },
-              "unit": "litre"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 6,
-            "w": 8,
-            "x": 9,
-            "y": 52
-          },
-          "id": 50,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "alias": "Tyre",
-              "datasource": {
-                "type": "influxdb",
-                "uid": "${DS_RACING}"
-              },
-              "groupBy": [
-                {
-                  "params": [
-                    "1s"
-                  ],
-                  "type": "time"
-                },
-                {
-                  "params": [
-                    "none"
-                  ],
-                  "type": "fill"
-                }
-              ],
-              "hide": false,
-              "measurement": "mqtt_consumer",
-              "orderByTime": "ASC",
-              "policy": "default",
-              "query": "FinalOutput = [\"_field\", \"_time\", \"_value\"]\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"FuelData_FuelCapacity\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: v.windowPeriod, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"FuelCapacity\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-              "refId": "FuelCapacity",
-              "resultFormat": "time_series",
-              "select": [
-                [
-                  {
-                    "params": [
-                      "telemetry_FrontLeftPressure"
-                    ],
-                    "type": "field"
-                  },
-                  {
-                    "params": [],
-                    "type": "max"
-                  }
-                ]
-              ],
-              "tags": []
-            },
-            {
-              "alias": "Wear",
-              "datasource": {
-                "type": "influxdb",
-                "uid": "${DS_RACING}"
-              },
-              "groupBy": [
-                {
-                  "params": [
-                    "1s"
-                  ],
-                  "type": "time"
-                },
-                {
-                  "params": [
-                    "none"
-                  ],
-                  "type": "fill"
-                }
-              ],
-              "hide": false,
-              "measurement": "mqtt_consumer",
-              "orderByTime": "ASC",
-              "policy": "default",
-              "query": "FinalOutput = [\"_field\", \"_time\", \"_value\"]\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"FuelData_FuelLeft\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: v.windowPeriod, fn: max, createEmpty: false)\r\n      \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"FuelLeft\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-              "refId": "FuelLeft",
-              "resultFormat": "time_series",
-              "select": [
-                [
-                  {
-                    "params": [
-                      "telemetry_FrontLeftPercentWear"
-                    ],
-                    "type": "field"
-                  },
-                  {
-                    "params": [],
-                    "type": "max"
-                  }
-                ]
-              ],
-              "tags": []
-            }
-          ],
-          "title": "Fuel",
-          "transformations": [],
-          "transparent": true,
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "fixedColor": "orange",
-                "mode": "thresholds"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 12,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 2,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "area"
-                }
-              },
-              "mappings": [],
-              "noValue": "0",
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "red",
-                    "value": null
-                  },
-                  {
-                    "color": "green",
-                    "value": 26
-                  },
-                  {
-                    "color": "semi-dark-red",
-                    "value": 27
-                  }
-                ]
-              },
-              "unit": "pressurepsi"
-            },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Tyre"
-                },
-                "properties": [
-                  {
-                    "id": "color",
-                    "value": {
-                      "fixedColor": "text",
-                      "mode": "fixed"
-                    }
-                  },
-                  {
-                    "id": "custom.axisPlacement",
-                    "value": "hidden"
-                  },
-                  {
-                    "id": "custom.hideFrom",
-                    "value": {
-                      "legend": true,
-                      "tooltip": true,
-                      "viz": true
-                    }
-                  }
-                ]
-              }
-            ]
-          },
-          "gridPos": {
-            "h": 6,
-            "w": 7,
-            "x": 17,
-            "y": 52
-          },
-          "id": 49,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "alias": "Tyre",
-              "datasource": {
-                "type": "influxdb",
-                "uid": "${DS_RACING}"
-              },
-              "groupBy": [
-                {
-                  "params": [
-                    "1s"
-                  ],
-                  "type": "time"
-                },
-                {
-                  "params": [
-                    "none"
-                  ],
-                  "type": "fill"
-                }
-              ],
-              "hide": false,
-              "measurement": "mqtt_consumer",
-              "orderByTime": "ASC",
-              "policy": "default",
-              "query": "FinalOutput = [\"_field\", \"_time\", \"_value\"]\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"EngineData_EngineOilPressure\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: v.windowPeriod, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Oil\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-              "refId": "Oil",
-              "resultFormat": "time_series",
-              "select": [
-                [
-                  {
-                    "params": [
-                      "telemetry_FrontLeftPressure"
-                    ],
-                    "type": "field"
-                  },
-                  {
-                    "params": [],
-                    "type": "max"
-                  }
-                ]
-              ],
-              "tags": []
-            },
-            {
-              "alias": "Wear",
-              "datasource": {
-                "type": "influxdb",
-                "uid": "${DS_RACING}"
-              },
-              "groupBy": [
-                {
-                  "params": [
-                    "1s"
-                  ],
-                  "type": "time"
-                },
-                {
-                  "params": [
-                    "none"
-                  ],
-                  "type": "fill"
-                }
-              ],
-              "hide": false,
-              "measurement": "mqtt_consumer",
-              "orderByTime": "ASC",
-              "policy": "default",
-              "query": "FinalOutput = [\"_field\", \"_time\", \"_value\"]\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"FuelData_FuelPressure\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: v.windowPeriod, fn: max, createEmpty: false)\r\n      \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Fuel\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-              "refId": "Fuel",
-              "resultFormat": "time_series",
-              "select": [
-                [
-                  {
-                    "params": [
-                      "telemetry_FrontLeftPercentWear"
-                    ],
-                    "type": "field"
-                  },
-                  {
-                    "params": [],
-                    "type": "max"
-                  }
-                ]
-              ],
-              "tags": []
-            }
-          ],
-          "title": "Engine PSI",
-          "transformations": [],
-          "transparent": true,
-          "type": "timeseries"
-        },
-        {
-          "collapsed": false,
-          "gridPos": {
-            "h": 1,
-            "w": 24,
-            "x": 0,
-            "y": 58
-          },
-          "id": 55,
-          "panels": [],
-          "title": "Weather Distance Flags",
-          "type": "row"
-        },
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 16,
-                "gradientMode": "opacity",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "decimals": 2,
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "celsius"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 4,
-            "w": 24,
-            "x": 0,
-            "y": 59
-          },
-          "id": 31,
-          "options": {
-            "legend": {
-              "calcs": [
-                "min",
-                "mean",
-                "max"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "alias": "Ambient Temp",
-              "datasource": {
-                "type": "influxdb",
-                "uid": "${DS_RACING}"
-              },
-              "groupBy": [
-                {
-                  "params": [
-                    "1s"
-                  ],
-                  "type": "time"
-                },
-                {
-                  "params": [
-                    "none"
-                  ],
-                  "type": "fill"
-                }
-              ],
-              "measurement": "mqtt_consumer",
-              "orderByTime": "ASC",
-              "policy": "default",
-              "query": "FinalOutput = [\"_field\", \"_time\", \"_value\"]\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Conditions_Temperature_Ambient\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: v.windowPeriod, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Ambient\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-              "refId": "Ambient",
-              "resultFormat": "time_series",
-              "select": [
-                [
-                  {
-                    "params": [
-                      "telemetry_AmbientTemperature"
-                    ],
-                    "type": "field"
-                  },
-                  {
-                    "params": [],
-                    "type": "max"
-                  }
-                ]
-              ],
-              "tags": []
-            },
-            {
-              "alias": "Track Temp",
-              "datasource": {
-                "type": "influxdb",
-                "uid": "${DS_RACING}"
-              },
-              "groupBy": [
-                {
-                  "params": [
-                    "1s"
-                  ],
-                  "type": "time"
-                },
-                {
-                  "params": [
-                    "none"
-                  ],
-                  "type": "fill"
-                }
-              ],
-              "hide": false,
-              "measurement": "mqtt_consumer",
-              "orderByTime": "ASC",
-              "policy": "default",
-              "query": "FinalOutput = [\"_field\", \"_time\", \"_value\"]\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Conditions_Temperature_Track\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: v.windowPeriod, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Track\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-              "refId": "Track",
-              "resultFormat": "time_series",
-              "select": [
-                [
-                  {
-                    "params": [
-                      "telemetry_TrackTemperature"
-                    ],
-                    "type": "field"
-                  },
-                  {
-                    "params": [],
-                    "type": "mean"
-                  }
-                ]
-              ],
-              "tags": []
-            }
-          ],
-          "title": "Temperature Conditions",
-          "transparent": true,
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 97,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "stepBefore",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "decimals": 0,
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "transparent",
-                    "value": null
-                  },
-                  {
-                    "color": "dark-green",
-                    "value": 0
-                  },
-                  {
-                    "color": "dark-yellow",
-                    "value": 1
-                  },
-                  {
-                    "color": "dark-blue",
-                    "value": 3
-                  },
-                  {
-                    "color": "#ffffff",
-                    "value": 6
-                  },
-                  {
-                    "color": "#343434",
-                    "value": 7
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 63
-          },
-          "id": 33,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "alias": "Flag",
-              "datasource": {
-                "type": "influxdb",
-                "uid": "${DS_RACING}"
-              },
-              "groupBy": [
-                {
-                  "params": [
-                    "1s"
-                  ],
-                  "type": "time"
-                },
-                {
-                  "params": [
-                    "null"
-                  ],
-                  "type": "fill"
-                }
-              ],
-              "measurement": "mqtt_consumer",
-              "orderByTime": "ASC",
-              "policy": "default",
-              "query": "FinalOutput = [\"_field\", \"_time\", \"_value\"]\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Session_Flag\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Flag\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-              "refId": "A",
-              "resultFormat": "time_series",
-              "select": [
-                [
-                  {
-                    "params": [
-                      "telemetry_Flag"
-                    ],
-                    "type": "field"
-                  },
-                  {
-                    "params": [],
-                    "type": "max"
-                  }
-                ]
-              ],
-              "tags": []
-            }
-          ],
-          "title": "Flag",
-          "transparent": true,
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "fixedColor": "orange",
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 12,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 2,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "min": 0,
-              "noValue": "0",
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "red",
-                    "value": null
-                  },
-                  {
-                    "color": "green",
-                    "value": 26
-                  },
-                  {
-                    "color": "semi-dark-red",
-                    "value": 27
-                  }
-                ]
-              },
-              "unit": "lengthm"
-            },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "%"
-                },
-                "properties": [
-                  {
-                    "id": "custom.axisPlacement",
-                    "value": "right"
-                  },
-                  {
-                    "id": "unit",
-                    "value": "percentunit"
-                  }
-                ]
-              }
-            ]
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 63
-          },
-          "id": 56,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "alias": "Tyre",
-              "datasource": {
-                "type": "influxdb",
-                "uid": "${DS_RACING}"
-              },
-              "groupBy": [
-                {
-                  "params": [
-                    "1s"
-                  ],
-                  "type": "time"
-                },
-                {
-                  "params": [
-                    "none"
-                  ],
-                  "type": "fill"
-                }
-              ],
-              "hide": false,
-              "measurement": "mqtt_consumer",
-              "orderByTime": "ASC",
-              "policy": "default",
-              "query": "FinalOutput = [\"_field\", \"_time\", \"_value\"]\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"DistanceRoundTrack\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Distance\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-              "refId": "Distance",
-              "resultFormat": "time_series",
-              "select": [
-                [
-                  {
-                    "params": [
-                      "telemetry_FrontLeftPressure"
-                    ],
-                    "type": "field"
-                  },
-                  {
-                    "params": [],
-                    "type": "max"
-                  }
-                ]
-              ],
-              "tags": []
-            },
-            {
-              "datasource": {
-                "type": "influxdb",
-                "uid": "${DS_RACING}"
-              },
-              "hide": false,
-              "query": "FinalOutput = [\"_field\", \"_time\", \"_value\"]\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Track_Length\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Track Length\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-              "refId": "Track_Length"
-            }
-          ],
-          "title": "Distance in Meters",
-          "transformations": [
-            {
-              "id": "calculateField",
-              "options": {
-                "alias": "%",
-                "binary": {
-                  "left": "Distance",
-                  "operator": "/",
-                  "reducer": "sum",
-                  "right": "Track Length"
-                },
-                "mode": "binary",
-                "reduce": {
-                  "reducer": "sum"
-                }
-              }
-            }
-          ],
-          "transparent": true,
-          "type": "timeseries"
-        },
-        {
-          "collapsed": false,
-          "gridPos": {
-            "h": 1,
-            "w": 24,
-            "x": 0,
-            "y": 71
-          },
-          "id": 57,
-          "panels": [],
-          "title": "Work In Progress",
-          "type": "row"
+          "query": "import \"date\"\r\nfields = [\"_time\", \"GameName\", \"user\", \"CarModel\", \"TrackCode\", \"SessionId\", \"SessionTypeName\"]\r\njfields = [\"GameName\", \"user\", \"CarModel\", \"TrackCode\", \"SessionId\", \"SessionTypeName\"]\r\n\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\ndata = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"CurrentLapTime\")\r\n  |> keep(columns: fields)\r\n\r\nmin = data\r\n  |> first(column: \"_time\")\r\n\r\nmax = data\r\n  |> last(column: \"_time\")\r\n\r\njoin(tables: {min: min, max: max}, on: jfields, method: \"inner\")\r\n  |> group()  \r\n  \r\n  |> drop(columns: [\"SessionId\",  \"user\" ])\r\n  |> yield()",
+          "refId": "A"
         }
       ],
-      "refresh": "",
-      "revision": 1,
-      "schemaVersion": 38,
-      "style": "dark",
-      "tags": [],
-      "templating": {
-        "list": [
-          {
-            "current": {
-              "selected": true,
-              "text": "Km/h",
-              "value": "3.6"
+      "title": "Session Info",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Duration": true
             },
-            "hide": 0,
-            "includeAll": false,
-            "label": "Speed",
-            "multi": false,
-            "name": "Speed",
-            "options": [
+            "indexByName": {
+              "CarModel": 4,
+              "Duration": 3,
+              "GameName": 5,
+              "SessionId": 8,
+              "SessionType": 7,
+              "TrackCode": 6,
+              "_time_max": 2,
+              "_time_min": 1,
+              "user": 0
+            },
+            "renameByName": {
+              "CarModel": "Car Model",
+              "Duration": "",
+              "GameName": "Game",
+              "SessionTypeName": "Session Type",
+              "TrackCode": "Track",
+              "_time_max": "Stop",
+              "_time_min": "Start",
+              "user": "User"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Duration",
+            "binary": {
+              "left": "Stop",
+              "operator": "-",
+              "reducer": "sum",
+              "right": "Start"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_RACING}"
+      },
+      "description": "Times are base only in valid laps.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "center",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": false,
+            "inspect": false,
+            "minWidth": 50
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
               {
-                "selected": true,
-                "text": "Km/h",
-                "value": "3.6"
+                "color": "green",
+                "value": null
               },
               {
-                "selected": false,
-                "text": "MPH",
-                "value": "2.236936292054"
+                "color": "red",
+                "value": 80
               }
-            ],
-            "query": "Km/h : 3.6 , MPH : 2.236936292054",
-            "queryValue": "",
-            "skipUrlSync": false,
-            "type": "custom"
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Track"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "lengthm"
+              },
+              {
+                "id": "custom.width",
+                "value": 82
+              }
+            ]
           },
           {
-            "current": {
-              "isNone": true,
-              "selected": false,
-              "text": "None",
-              "value": ""
+            "matcher": {
+              "id": "byName",
+              "options": "Odometer"
             },
-            "datasource": {
-              "type": "influxdb",
-              "uid": "${DS_RACING}"
-            },
-            "definition": "from(bucket: \"racing\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"Gear\")\r\n  |> keep(columns: [\"user\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> first()\r\n  |> group(columns: [])\r\n  |> drop(columns: [\"_value\",\"_time\"])",
-            "hide": 0,
-            "includeAll": false,
-            "multi": false,
-            "name": "User",
-            "options": [],
-            "query": "from(bucket: \"racing\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"Gear\")\r\n  |> keep(columns: [\"user\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> first()\r\n  |> group(columns: [])\r\n  |> drop(columns: [\"_value\",\"_time\"])",
-            "refresh": 2,
-            "regex": "",
-            "skipUrlSync": false,
-            "sort": 1,
-            "type": "query"
+            "properties": [
+              {
+                "id": "unit",
+                "value": "lengthm"
+              },
+              {
+                "id": "custom.width",
+                "value": 84
+              }
+            ]
           },
           {
-            "current": {
-              "isNone": true,
-              "selected": false,
-              "text": "None",
-              "value": ""
+            "matcher": {
+              "id": "byName",
+              "options": "Avg Lap Time"
             },
-            "datasource": {
-              "type": "influxdb",
-              "uid": "${DS_RACING}"
+            "properties": [
+              {
+                "id": "unit",
+                "value": "clocks"
+              },
+              {
+                "id": "custom.width",
+                "value": 125
+              },
+              {
+                "id": "decimals",
+                "value": 2
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Max Lap Time"
             },
-            "definition": "from(bucket: \"racing\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"Gear\")\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> keep(columns: [\"SessionId\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> first()\r\n  |> group(columns: [])\r\n  |> drop(columns: [\"_value\",\"_time\"])",
-            "hide": 0,
-            "includeAll": false,
-            "label": "SessionId",
-            "multi": false,
-            "name": "SessionId",
-            "options": [],
-            "query": "from(bucket: \"racing\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"Gear\")\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> keep(columns: [\"SessionId\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> first()\r\n  |> group(columns: [])\r\n  |> drop(columns: [\"_value\",\"_time\"])",
-            "refresh": 1,
-            "regex": "",
-            "skipUrlSync": false,
-            "sort": 3,
-            "type": "query"
+            "properties": [
+              {
+                "id": "unit",
+                "value": "clocks"
+              },
+              {
+                "id": "custom.width",
+                "value": 128
+              },
+              {
+                "id": "decimals",
+                "value": 2
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Top(Km/h)"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "Speed"
+              },
+              {
+                "id": "decimals",
+                "value": 1
+              },
+              {
+                "id": "custom.width",
+                "value": 104
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Avg(Km/h)"
+            },
+            "properties": [
+              {
+                "id": "decimals",
+                "value": 1
+              },
+              {
+                "id": "unit",
+                "value": "Speed"
+              },
+              {
+                "id": "custom.width",
+                "value": 103
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Total"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 72
+              },
+              {
+                "id": "unit",
+                "value": "Laps"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Avg/Max"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              },
+              {
+                "id": "decimals",
+                "value": 3
+              },
+              {
+                "id": "custom.width",
+                "value": 103
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "P.Top"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 58
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "P.Low"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 56
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Fuel Used"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "litre"
+              },
+              {
+                "id": "custom.width",
+                "value": 88
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Fuel/Lap "
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "litre"
+              },
+              {
+                "id": "custom.width",
+                "value": 81
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Fuel Left "
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 76
+              },
+              {
+                "id": "unit",
+                "value": "litre"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Best Lap Time"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 134
+              },
+              {
+                "id": "unit",
+                "value": "clocks"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "AVG/Best"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 81
+              },
+              {
+                "id": "unit",
+                "value": "s"
+              },
+              {
+                "id": "decimals",
+                "value": 3
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "thresholds"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "text",
+                      "value": null
+                    },
+                    {
+                      "color": "green",
+                      "value": -0.01
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 0.01
+                    }
+                  ]
+                }
+              }
+            ]
           }
         ]
       },
-      "time": {
-        "from": "now-15m",
-        "to": "now"
+      "gridPos": {
+        "h": 4,
+        "w": 24,
+        "x": 0,
+        "y": 5
       },
-      "timepicker": {},
-      "timezone": "",
-      "title": "Session Details Extended",
-      "uid": "e12c7ccb-ff51-4525-b5da-0d783a1019ef",
-      "version": 41,
-      "weekStart": ""
+      "id": 60,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": [],
+          "reducer": [
+            "changeCount"
+          ],
+          "show": false
+        },
+        "frameIndex": 6,
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "10.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "query": "import \"date\"\r\nFinalOutput = [\"SessionId\", \"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"CurrentLap\" and r._value > 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1d, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value,  _time:r._time, _field:\"Total Laps\"}))\r\n  |> sort(columns: [\"_value\"], desc: false)\r\n  \r\n  |> keep(columns:FinalOutput)\r\n  \r\nNamedSeries |> yield()",
+          "refId": "Total Laps"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "hide": false,
+          "query": "import \"date\"\r\nFinalOutput = [\"SessionId\", \"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Track_Length\" and r._value >= 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1d, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value,  _time:r._time, _field:\"Track_Length\"}))\r\n  |> keep(columns:FinalOutput)\r\nNamedSeries |> yield()",
+          "refId": "Track"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "hide": false,
+          "query": "import \"date\"\r\nFinalOutput = [\"SessionId\", \"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"LapTimePrevious\" and r._value > 0)\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1d, fn: mean, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Avg Lap Time\"}))\r\n  |> keep(columns:FinalOutput)\r\nNamedSeries |> yield()",
+          "refId": "Laps"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "hide": false,
+          "query": "import \"date\"\r\nFinalOutput = [\"SessionId\", \"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"CurrentLapTime\" and r._value > 0)\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1d, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Max Lap Time\"}))\r\n  |> keep(columns:FinalOutput)\r\nNamedSeries |> yield()",
+          "refId": "MaxLap"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "hide": false,
+          "query": "import \"date\"\r\nFinalOutput = [\"SessionId\", \"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"SpeedMs\" and r._value > 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1d, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Top Speed ms\"}))\r\n  |> keep(columns:FinalOutput)\r\nNamedSeries |> yield()",
+          "refId": "Top Speed"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "hide": false,
+          "query": "import \"date\"\r\nFinalOutput = [\"SessionId\", \"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"SpeedMs\" and r._value > 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1d, fn: mean, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Avg Speed ms\"}))\r\n  |> keep(columns:FinalOutput)\r\nNamedSeries |> yield()",
+          "refId": "AVG Speed"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "hide": false,
+          "query": "import \"date\"\r\nFinalOutput = [\"SessionId\", \"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Session_Position_Overall\" and r._value > 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1d, fn: min, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"P.Top\"}))\r\n  |> keep(columns:FinalOutput)\r\nNamedSeries |> yield()",
+          "refId": "Top"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "hide": false,
+          "query": "import \"date\"\r\nFinalOutput = [\"SessionId\", \"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Session_Position_Overall\" and r._value > 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1d, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"P.Low\"}))\r\n  |> keep(columns:FinalOutput)\r\nNamedSeries |> yield()",
+          "refId": "Low"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "hide": false,
+          "query": "import \"date\"\r\nFinalOutput = [\"SessionId\", \"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"FuelData_FuelLeft\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1d, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"MaxFuel\"}))\r\n  |> keep(columns:FinalOutput)\r\nNamedSeries |> yield()",
+          "refId": "FuelMax"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "hide": false,
+          "query": "import \"date\"\r\nFinalOutput = [\"SessionId\", \"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"FuelData_FuelLeft\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1d, fn: min, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"MinFuel\"}))\r\n  |> keep(columns:FinalOutput)\r\nNamedSeries |> yield()",
+          "refId": "FuelLeft"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "hide": false,
+          "query": "import \"date\"\r\nFinalOutput = [\"SessionId\", \"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Session_PlayerClassSessionBestLapTime\" and r._value >= 0)\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1d, fn: min, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Best Lap Time\"}))\r\n  |> keep(columns:FinalOutput)\r\nNamedSeries |> yield()",
+          "refId": "BestLap"
+        }
+      ],
+      "title": "Session Stats",
+      "transformations": [
+        {
+          "id": "joinByField",
+          "options": {
+            "byField": "Time",
+            "mode": "outer"
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Distance",
+            "binary": {
+              "left": "Total Laps",
+              "operator": "*",
+              "reducer": "sum",
+              "right": "Track_Length"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Avg/Max",
+            "binary": {
+              "left": "Avg Lap Time",
+              "operator": "-",
+              "reducer": "sum",
+              "right": "Max Lap Time"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "AVG/Best",
+            "binary": {
+              "left": "Avg Lap Time",
+              "operator": "-",
+              "reducer": "sum",
+              "right": "Best Lap Time"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Top(${Speed:text})",
+            "binary": {
+              "left": "Top Speed ms",
+              "operator": "*",
+              "reducer": "sum",
+              "right": "${Speed}"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Avg(${Speed:text})",
+            "binary": {
+              "left": "Avg Speed ms",
+              "operator": "*",
+              "reducer": "sum",
+              "right": "${Speed}"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Fuel Used",
+            "binary": {
+              "left": "MinFuel",
+              "operator": "-",
+              "reducer": "sum",
+              "right": "MaxFuel"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Fuel/Lap ",
+            "binary": {
+              "left": "Fuel Used",
+              "operator": "/",
+              "reducer": "sum",
+              "right": "Total Laps"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Avg Speed ms": true,
+              "MaxFuel": true,
+              "MinFuel": false,
+              "Time": true,
+              "Top Speed ms": true
+            },
+            "indexByName": {
+              "AVG/Best": 10,
+              "Avg Lap Time": 6,
+              "Avg Speed ms": 12,
+              "Avg/Max": 9,
+              "Best Lap Time": 7,
+              "Distance": 5,
+              "Fuel Used": 14,
+              "Fuel/Lap ": 15,
+              "Max Lap Time": 8,
+              "MaxFuel": 13,
+              "MinFuel": 16,
+              "P.Low": 3,
+              "P.Top": 2,
+              "Time": 0,
+              "Top Speed ms": 11,
+              "Total Laps": 1,
+              "Track_Length": 4
+            },
+            "renameByName": {
+              "Distance": "Odometer",
+              "MinFuel": "Fuel Left ",
+              "Total Laps": "Total",
+              "Track_Length": "Track"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_RACING}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "center",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": false,
+            "inspect": false,
+            "minWidth": 50
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Track Length"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "lengthm"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "CurrentLapTime"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "CarNumber"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 95
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "CountryCode"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 69
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "iRating"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 76
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Driver"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 144
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 11,
+        "x": 0,
+        "y": 9
+      },
+      "id": 58,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "frameIndex": 1,
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "10.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "query": "import \"influxdata/influxdb/schema\"\r\nfrom(bucket: \"racing\")\r\n  |> range(start: -1y, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> filter(fn: (r) => r[\"_field\"] =~ /^(Session_CarNumber|Session_iRating|Session_StrengthOfField)$/)\r\n  |> limit(n:1)\r\n  |> schema.fieldsAsCols() \r\n  |> drop(columns: [\"GameName\",  \"CarModel\", \"_time\", \"TrackCode\", \"SessionId\", \"_start\",\"_stop\", \"SessionTypeName\", \"_measurement\", \"host\", \"topic\", \"UserId\", \"user\" ])\r\n  |> group(columns: [])  \r\n\r\n \r\n  \r\n\r\n\r\n",
+          "refId": "A"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {
+              "CountryCode": 2,
+              "Driver": 1,
+              "Session_CarNumber": 0,
+              "Session_iRating": 4,
+              "Team": 3
+            },
+            "renameByName": {
+              "Duration": "Minutes",
+              "Session_CarNumber": "CarNumber",
+              "Session_StrengthOfField": "Strength Of Field",
+              "Session_iRating": "iRating",
+              "Track_Length": "Track Length",
+              "_time_max": "Stop",
+              "_time_min": "Start",
+              "_value": "Car Number",
+              "user": "User"
+            }
+          }
+        }
+      ],
+      "transparent": true,
+      "type": "table"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 12
+      },
+      "id": 11,
+      "panels": [],
+      "title": "Tyres Position Penalties",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_RACING}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "yellow",
+            "mode": "thresholds"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "area"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "dark-blue",
+                "value": null
+              },
+              {
+                "color": "dark-yellow",
+                "value": 70
+              },
+              {
+                "color": "dark-green",
+                "value": 80
+              },
+              {
+                "color": "dark-orange",
+                "value": 90
+              },
+              {
+                "color": "dark-red",
+                "value": 100
+              }
+            ]
+          },
+          "unit": "celsius"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "BrakeTemp"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "light-blue",
+                      "value": null
+                    },
+                    {
+                      "color": "light-green",
+                      "value": 350
+                    },
+                    {
+                      "color": "light-red",
+                      "value": 650
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "custom.scaleDistribution",
+                "value": {
+                  "type": "linear"
+                }
+              },
+              {
+                "id": "custom.thresholdsStyle",
+                "value": {
+                  "mode": "dashed"
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 5,
+        "x": 0,
+        "y": 13
+      },
+      "id": 41,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Brake",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "0"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Front_Left_BrakeTemp\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Brake\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "BrakeTemp",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_TyreData_Front_Left_BrakeTemp"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Core",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "0"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Front_Left_CenterTemp\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Tyre Core\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()\r\n ",
+          "refId": "TyreCore",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_TyreData_Front_Left_CenterTemp"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Front Left Temp",
+      "transformations": [],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_RACING}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "yellow",
+            "mode": "thresholds"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "area"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "dark-blue",
+                "value": null
+              },
+              {
+                "color": "dark-yellow",
+                "value": 70
+              },
+              {
+                "color": "dark-green",
+                "value": 80
+              },
+              {
+                "color": "dark-orange",
+                "value": 90
+              },
+              {
+                "color": "dark-red",
+                "value": 100
+              }
+            ]
+          },
+          "unit": "celsius"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "BrakeTemp"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "light-blue",
+                      "value": null
+                    },
+                    {
+                      "color": "light-green",
+                      "value": 350
+                    },
+                    {
+                      "color": "light-red",
+                      "value": 650
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "custom.scaleDistribution",
+                "value": {
+                  "type": "linear"
+                }
+              },
+              {
+                "id": "custom.thresholdsStyle",
+                "value": {
+                  "mode": "dashed"
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 5,
+        "x": 5,
+        "y": 13
+      },
+      "id": 36,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Core",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "0"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Front_Right_CenterTemp\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Tyre Core\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()\r\n ",
+          "refId": "TyreCore",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_TyreData_Front_Left_CenterTemp"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Brake",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "0"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Front_Right_BrakeTemp\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Brake\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "BrakeTemp",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_TyreData_Front_Left_BrakeTemp"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Front Right Temp",
+      "transformations": [],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_RACING}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-RdYlGr"
+          },
+          "decimals": 0,
+          "mappings": [],
+          "min": 1,
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 2,
+        "x": 10,
+        "y": 13
+      },
+      "id": 22,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "vertical",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {
+          "titleSize": 1
+        },
+        "textMode": "value"
+      },
+      "pluginVersion": "10.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Session_Position_Overall\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: last, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Position\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_Session_Position_Overall"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Position",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_RACING}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-RdYlGr"
+          },
+          "decimals": 0,
+          "mappings": [],
+          "min": 1,
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 2,
+        "x": 12,
+        "y": 13
+      },
+      "id": 24,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {
+          "titleSize": 1
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Session_NumCars_Overall\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: ${SessionLen}s, fn: last, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Opponents\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_Session_NumCars_Overall"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Opponents ",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_RACING}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "orange",
+            "mode": "thresholds"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "area"
+            }
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 26
+              },
+              {
+                "color": "semi-dark-red",
+                "value": 27
+              }
+            ]
+          },
+          "unit": "pressurepsi"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Tyre"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "text",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "hidden"
+              },
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                }
+              },
+              {
+                "id": "min",
+                "value": 0
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Wear"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "unit",
+                "value": "percent"
+              },
+              {
+                "id": "max"
+              },
+              {
+                "id": "custom.thresholdsStyle",
+                "value": {
+                  "mode": "dashed"
+                }
+              },
+              {
+                "id": "min"
+              },
+              {
+                "id": "custom.scaleDistribution",
+                "value": {
+                  "type": "linear"
+                }
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "thresholds"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "light-yellow",
+                      "value": 50
+                    },
+                    {
+                      "color": "semi-dark-orange",
+                      "value": 70
+                    },
+                    {
+                      "color": "semi-dark-red",
+                      "value": 80
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 90
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "x10"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "hidden"
+              },
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 5,
+        "x": 14,
+        "y": 13
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Tyre",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Front_Left_Pressure\" and r._value >= 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Tyre\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "TyrePressure",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_FrontLeftPressure"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Wear",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Front_Left_PercentWear\" and r._value >= 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n      \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Wear\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "TyreWear",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_FrontLeftPercentWear"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Front Left (PSI-Wear)",
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "x10",
+            "binary": {
+              "left": "Tyre",
+              "operator": "*",
+              "reducer": "sum",
+              "right": "10"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "PSI",
+            "binary": {
+              "left": "x10",
+              "operator": "/",
+              "reducer": "sum",
+              "right": "70.3070"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": false
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Tyre": true,
+              "x10": true
+            },
+            "indexByName": {},
+            "renameByName": {}
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_RACING}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "orange",
+            "mode": "thresholds"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "area"
+            }
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 26
+              },
+              {
+                "color": "semi-dark-red",
+                "value": 27
+              }
+            ]
+          },
+          "unit": "pressurepsi"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Tyre"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "text",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "hidden"
+              },
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": true
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Wear"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "unit",
+                "value": "percent"
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "#EAB839",
+                      "value": 60
+                    },
+                    {
+                      "color": "semi-dark-orange",
+                      "value": 70
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 90
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "max"
+              },
+              {
+                "id": "custom.thresholdsStyle",
+                "value": {
+                  "mode": "dashed"
+                }
+              },
+              {
+                "id": "min",
+                "value": 0
+              },
+              {
+                "id": "custom.scaleDistribution",
+                "value": {
+                  "type": "linear"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "x10"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "hidden"
+              },
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 5,
+        "x": 19,
+        "y": 13
+      },
+      "id": 42,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Tyre",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Front_Right_Pressure\"  and r._value >= 0)\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Tyre\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "TyrePressure",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_FrontLeftPressure"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Wear",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Front_Right_PercentWear\" and r._value >= 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n      \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Wear\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "TyreWear",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_FrontLeftPercentWear"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Front Right (PSI-Wear)",
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "x10",
+            "binary": {
+              "left": "Tyre",
+              "operator": "*",
+              "reducer": "sum",
+              "right": "10"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "PSI",
+            "binary": {
+              "left": "x10",
+              "operator": "/",
+              "reducer": "sum",
+              "right": "70.3070"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": false
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_RACING}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-RdYlGr"
+          },
+          "decimals": 0,
+          "mappings": [],
+          "min": -1,
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 2,
+        "x": 10,
+        "y": 17
+      },
+      "id": 23,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Penalties_CutTrackWarnings\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: ${SessionLen}s, fn: max, createEmpty: false)\r\n\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Cuts\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_CutTrackWarnings"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Cuts",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_RACING}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-RdYlGr"
+          },
+          "decimals": 0,
+          "mappings": [],
+          "min": -1,
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 2,
+        "x": 12,
+        "y": 17
+      },
+      "id": 45,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Penalties_Incidents\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: ${SessionLen}s, fn: max, createEmpty: false)\r\n\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Incidents\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_CutTrackWarnings"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Incidents",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_RACING}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "yellow",
+            "mode": "thresholds"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "area"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "dark-blue",
+                "value": null
+              },
+              {
+                "color": "dark-yellow",
+                "value": 70
+              },
+              {
+                "color": "dark-green",
+                "value": 80
+              },
+              {
+                "color": "dark-orange",
+                "value": 90
+              },
+              {
+                "color": "dark-red",
+                "value": 100
+              }
+            ]
+          },
+          "unit": "celsius"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "BrakeTemp"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "light-blue",
+                      "value": null
+                    },
+                    {
+                      "color": "light-green",
+                      "value": 350
+                    },
+                    {
+                      "color": "light-red",
+                      "value": 650
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "custom.scaleDistribution",
+                "value": {
+                  "type": "linear"
+                }
+              },
+              {
+                "id": "custom.thresholdsStyle",
+                "value": {
+                  "mode": "dashed"
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 5,
+        "x": 0,
+        "y": 18
+      },
+      "id": 39,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Core",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "0"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Rear_Left_CenterTemp\" and r._value >= 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Tyre Core\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()\r\n ",
+          "refId": "TyreCore",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_TyreData_Front_Left_CenterTemp"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Brake",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "0"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Rear_Left_BrakeTemp\" and r._value >=0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Brake\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "BrakeTemp",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_TyreData_Front_Left_BrakeTemp"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Rear Left Temp",
+      "transformations": [],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_RACING}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "yellow",
+            "mode": "thresholds"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "area"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "dark-blue",
+                "value": null
+              },
+              {
+                "color": "dark-yellow",
+                "value": 70
+              },
+              {
+                "color": "dark-green",
+                "value": 80
+              },
+              {
+                "color": "dark-orange",
+                "value": 90
+              },
+              {
+                "color": "dark-red",
+                "value": 100
+              }
+            ]
+          },
+          "unit": "celsius"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "BrakeTemp"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "light-blue",
+                      "value": null
+                    },
+                    {
+                      "color": "light-green",
+                      "value": 350
+                    },
+                    {
+                      "color": "light-red",
+                      "value": 650
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "custom.scaleDistribution",
+                "value": {
+                  "type": "linear"
+                }
+              },
+              {
+                "id": "custom.thresholdsStyle",
+                "value": {
+                  "mode": "dashed"
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 5,
+        "x": 5,
+        "y": 18
+      },
+      "id": 40,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Core",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "0"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Rear_Right_CenterTemp\" and r._value >= 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Tyre Core\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()\r\n ",
+          "refId": "TyreCore",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_TyreData_Front_Left_CenterTemp"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Brake",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "0"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Rear_Right_BrakeTemp\" and r._value >=0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Brake\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "BrakeTemp",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_TyreData_Front_Left_BrakeTemp"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Rear Right Temp",
+      "transformations": [],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_RACING}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "orange",
+            "mode": "thresholds"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "area"
+            }
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 26
+              },
+              {
+                "color": "semi-dark-red",
+                "value": 27
+              }
+            ]
+          },
+          "unit": "pressurepsi"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Tyre"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "text",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "hidden"
+              },
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": true
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Wear"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "unit",
+                "value": "percent"
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 60
+                    },
+                    {
+                      "color": "semi-dark-orange",
+                      "value": 70
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 90
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "max"
+              },
+              {
+                "id": "custom.thresholdsStyle",
+                "value": {
+                  "mode": "dashed"
+                }
+              },
+              {
+                "id": "min",
+                "value": 0
+              },
+              {
+                "id": "custom.scaleDistribution",
+                "value": {
+                  "type": "linear"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "x10"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "hidden"
+              },
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 5,
+        "x": 14,
+        "y": 18
+      },
+      "id": 43,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Tyre",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Rear_Left_Pressure\" and r._value >= 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Tyre\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "TyrePressure",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_FrontLeftPressure"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Wear",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Rear_Left_PercentWear\" and r._value >= 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n      \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Wear\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "TyreWear",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_FrontLeftPercentWear"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Rear Left (PSI-Wear)",
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "x10",
+            "binary": {
+              "left": "Tyre",
+              "operator": "*",
+              "reducer": "sum",
+              "right": "10"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "PSI",
+            "binary": {
+              "left": "x10",
+              "operator": "/",
+              "reducer": "sum",
+              "right": "70.3070"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": false
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_RACING}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "orange",
+            "mode": "thresholds"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "area"
+            }
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 26
+              },
+              {
+                "color": "semi-dark-red",
+                "value": 27
+              }
+            ]
+          },
+          "unit": "pressurepsi"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Tyre"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "text",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "hidden"
+              },
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": true
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Wear"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "unit",
+                "value": "percent"
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 60
+                    },
+                    {
+                      "color": "semi-dark-orange",
+                      "value": 70
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 90
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "max"
+              },
+              {
+                "id": "custom.thresholdsStyle",
+                "value": {
+                  "mode": "dashed"
+                }
+              },
+              {
+                "id": "min",
+                "value": 0
+              },
+              {
+                "id": "custom.scaleDistribution",
+                "value": {
+                  "type": "linear"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "x10"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "hidden"
+              },
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 5,
+        "x": 19,
+        "y": 18
+      },
+      "id": 44,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Tyre",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Rear_Right_Pressure\" and r._value >= 0)\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Tyre\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "TyrePressure",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_FrontLeftPressure"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Wear",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Rear_Right_PercentWear\"  and r._value >= 0)\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n      \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Wear\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "TyreWear",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_FrontLeftPercentWear"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Rear Right (PSI-Wear)",
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "x10",
+            "binary": {
+              "left": "Tyre",
+              "operator": "*",
+              "reducer": "sum",
+              "right": "10"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "PSI",
+            "binary": {
+              "left": "x10",
+              "operator": "/",
+              "reducer": "sum",
+              "right": "70.3070"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": false
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_RACING}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-RdYlGr"
+          },
+          "decimals": 0,
+          "mappings": [],
+          "min": -1,
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 2,
+        "x": 10,
+        "y": 20
+      },
+      "id": 46,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Penalties_Total\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: ${SessionLen}s, fn: max, createEmpty: false)\r\n\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Penalties\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_CutTrackWarnings"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Penalties",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_RACING}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.1
+              },
+              {
+                "color": "yellow",
+                "value": 0.25
+              },
+              {
+                "color": "#88bf69",
+                "value": 0.5
+              },
+              {
+                "color": "dark-green",
+                "value": 0.6
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 2,
+        "x": 12,
+        "y": 20
+      },
+      "id": 51,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^Fuel%$/",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "pluginVersion": "10.0.2",
+      "targets": [
+        {
+          "alias": "Tyre",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"FuelData_FuelCapacity\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"FuelCapacity\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "FuelCapacity",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_FrontLeftPressure"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Wear",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"FuelData_FuelLeft\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n      \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"FuelLeft\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "FuelLeft",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_FrontLeftPercentWear"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Fuel %",
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Fuel%",
+            "binary": {
+              "left": "FuelLeft",
+              "operator": "/",
+              "reducer": "sum",
+              "right": "FuelCapacity"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": true
+          }
+        }
+      ],
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 23
+      },
+      "id": 4,
+      "panels": [],
+      "title": "Time Speed Inputs",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_RACING}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "purple",
+            "mode": "fixed"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Lap time",
+            "axisPlacement": "left",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 51,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [
+            {
+              "options": {
+                "1": {
+                  "color": "green",
+                  "index": 0
+                },
+                "2": {
+                  "color": "purple",
+                  "index": 1
+                },
+                "3": {
+                  "color": "yellow",
+                  "index": 2
+                },
+                "4": {
+                  "color": "#a5f700",
+                  "index": 3
+                },
+                "5": {
+                  "color": "semi-dark-blue",
+                  "index": 4
+                },
+                "6": {
+                  "color": "#ba05f7",
+                  "index": 5
+                },
+                "7": {
+                  "color": "#0affb9",
+                  "index": 6
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "clocks"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "Lap"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "custom.axisLabel",
+                "value": "Laps Num"
+              },
+              {
+                "id": "unit",
+                "value": "none"
+              },
+              {
+                "id": "custom.scaleDistribution",
+                "value": {
+                  "type": "linear"
+                }
+              },
+              {
+                "id": "decimals",
+                "value": 0
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 2
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 10,
+        "x": 0,
+        "y": 24
+      },
+      "id": 18,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Last Lap",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"LapTimePrevious\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Lap Valid Time\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "LapTime",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_LapTimePrevious"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Lap",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"CurrentLap\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Lap #\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "Lap",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_CurrentLap"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Last Lap",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_RACING}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "#be60f2",
+            "mode": "fixed"
+          },
+          "decimals": 0,
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "light-red",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 10,
+        "y": 24
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "10.0.2",
+      "targets": [
+        {
+          "alias": "maxspeedms",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1m"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "0"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"SpeedMs\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1d, fn: max, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"maxspeedms\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_SpeedMs"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Top Speed",
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "${Speed:text}",
+            "binary": {
+              "left": "_value",
+              "operator": "*",
+              "reducer": "sum",
+              "right": "${Speed}"
+            },
+            "mode": "binary",
+            "reduce": {
+              "include": [
+                "mqtt_consumer.last"
+              ],
+              "reducer": "sum"
+            },
+            "replaceFields": true
+          }
+        }
+      ],
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_RACING}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "log": 2,
+              "type": "symlog"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "B"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Delta Behind"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "A"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Delta Front"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 10,
+        "x": 14,
+        "y": 24
+      },
+      "id": 20,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean"
+          ],
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Delta Front",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Session_Delta_Front\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Delta_Front\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_DeltaFront"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Delta Behind",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "0"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Session_Delta_Behind\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Delta_Behind\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_DeltaBehind"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Deltas",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_RACING}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "left",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SpeedMs"
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": true
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Sector"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "displayName",
+                "value": "Sector"
+              },
+              {
+                "id": "max",
+                "value": 3
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-yellow",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "PitLimitMs"
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": true
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Km/h"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-blue",
+                  "mode": "shades"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 29
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.4.7",
+      "targets": [
+        {
+          "alias": "maxspeedms",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"SpeedMs\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"SpeedMs\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "SpeedMs",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_SpeedMs"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Section",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"PitData_PitSpeedLimit\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"PitLimitMs\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "PitLimit",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_Sector"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "hide": false,
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Session_Sector\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Sector\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "Sector"
+        }
+      ],
+      "title": "Speed",
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "${Speed:text}",
+            "binary": {
+              "left": "SpeedMs",
+              "operator": "*",
+              "reducer": "sum",
+              "right": "${Speed}"
+            },
+            "mode": "binary",
+            "reduce": {
+              "include": [
+                "mqtt_consumer.last"
+              ],
+              "reducer": "sum"
+            },
+            "replaceFields": false
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Pit Limit",
+            "binary": {
+              "left": "PitLimitMs",
+              "operator": "*",
+              "reducer": "sum",
+              "right": "${Speed}"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        }
+      ],
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_RACING}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 2,
+            "gradientMode": "scheme",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "SteeringAngle"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "unit",
+                "value": "none"
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 22
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "super-light-orange",
+                  "mode": "fixed",
+                  "seriesBy": "min"
+                }
+              },
+              {
+                "id": "displayName",
+                "value": "SteeringAngle"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "Brake"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-red",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "displayName",
+                "value": "Brake"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "Throttle"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-green",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "displayName",
+                "value": "Throttle"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "Clutch"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Clutch"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 2
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "Handbrake"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Handbrake"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 35
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Brake",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "0"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Brake\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: last, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n  |> set(key: \"_field\", value: \"Brake\")\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Brake\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "Brake",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_Brake"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Throttle",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "0"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Throttle\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: last, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n  |> set(key: \"_field\", value: \"Throttle\")\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Throttle\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "Throttle",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_Throttle"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Steer",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "linear"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"SteeringAngle\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: last, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n  |> set(key: \"_field\", value: \"SteeringAngle\")\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"SteeringAngle\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "SteeringAngle",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_SteeringAngle"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Throttle",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "0"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Clutch\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: last, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n  |> set(key: \"_field\", value: \"Clutch\")\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Clutch\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "Clutch",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_Throttle"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Throttle",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "0"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Handbrake\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: last, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n  |> set(key: \"_field\", value: \"Handbrake\")\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Handbrake\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "Handbrake",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_Throttle"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Inputs",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 44
+      },
+      "id": 52,
+      "panels": [],
+      "title": "Engine Data ",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_RACING}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "series",
+            "axisLabel": "RPMs",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "Gear"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "displayName",
+                "value": "Gear"
+              },
+              {
+                "id": "custom.axisLabel",
+                "value": "Gears"
+              },
+              {
+                "id": "custom.lineInterpolation",
+                "value": "stepBefore"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "RPM"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "RPM"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "MaxRPM"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Max RPM"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 45
+      },
+      "id": 35,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"EngineData_EngineRpm\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n  |> set(key: \"_field\", value: \"EngineData_EngineRpm\")\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"EngineData_EngineRpm\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "RPM",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_Rpms"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Gear",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Gear\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: last, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n  |> set(key: \"_field\", value: \"Gear\")\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Gear\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "Gear",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_Gear"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Max",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"EngineData_MaxEngineRpm\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n  |> set(key: \"_field\", value: \"EngineData_MaxEngineRpm\")\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"EngineData_MaxEngineRpm\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "MaxRPM",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_EngineData_MaxEngineRpm"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Engine RPMs",
+      "transformations": [],
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_RACING}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds",
+            "seriesBy": "last"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "series",
+            "axisLabel": "%",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "area"
+            }
+          },
+          "decimals": 0,
+          "mappings": [],
+          "max": 1,
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "super-light-yellow",
+                "value": null
+              },
+              {
+                "color": "light-blue",
+                "value": 0
+              },
+              {
+                "color": "dark-green",
+                "value": 0.55
+              },
+              {
+                "color": "dark-red",
+                "value": 0.9
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 51
+      },
+      "id": 47,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"EngineData_EngineRpm\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n  |> set(key: \"_field\", value: \"EngineData_EngineRpm\")\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"EngineData_EngineRpm\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "RPM",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_Rpms"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Max",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"EngineData_MaxEngineRpm\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n  |> set(key: \"_field\", value: \"EngineData_MaxEngineRpm\")\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"EngineData_MaxEngineRpm\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "MaxRPM",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_EngineData_MaxEngineRpm"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Engine RPM %",
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "%RPM",
+            "binary": {
+              "left": "_value 1",
+              "operator": "/",
+              "reducer": "sum",
+              "right": "_value 2"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": true
+          }
+        }
+      ],
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_RACING}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "yellow",
+            "mode": "thresholds"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "area"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "dark-blue",
+                "value": null
+              },
+              {
+                "color": "dark-yellow",
+                "value": 70
+              },
+              {
+                "color": "dark-green",
+                "value": 80
+              },
+              {
+                "color": "dark-orange",
+                "value": 100
+              },
+              {
+                "color": "dark-red",
+                "value": 143
+              }
+            ]
+          },
+          "unit": "celsius"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "EngineOilTemp"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "blue",
+                      "value": null
+                    },
+                    {
+                      "color": "light-green",
+                      "value": 82
+                    },
+                    {
+                      "color": "orange",
+                      "value": 104
+                    },
+                    {
+                      "color": "red",
+                      "value": 140
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "custom.scaleDistribution",
+                "value": {
+                  "type": "linear"
+                }
+              },
+              {
+                "id": "custom.thresholdsStyle",
+                "value": {
+                  "mode": "dashed"
+                }
+              },
+              {
+                "id": "displayName",
+                "value": "Oil"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "WaterTemp"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Water"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 9,
+        "x": 0,
+        "y": 57
+      },
+      "id": 48,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Core",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "0"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"EngineData_EngineWaterTemp\" and r._value >=0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"EngineData_EngineWaterTemp\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()\r\n ",
+          "refId": "WaterTemp",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_TyreData_Front_Left_CenterTemp"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Brake",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "0"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"EngineData_EngineOilTemp\" and r._value >= 0)\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"EngineData_EngineOilTemp\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "EngineOilTemp",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_TyreData_Front_Left_BrakeTemp"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Engine Temps",
+      "transformations": [],
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_RACING}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "orange",
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 26
+              },
+              {
+                "color": "semi-dark-red",
+                "value": 27
+              }
+            ]
+          },
+          "unit": "litre"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 9,
+        "y": 57
+      },
+      "id": 50,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Tyre",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"FuelData_FuelCapacity\" and r._value >= 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"FuelCapacity\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "FuelCapacity",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_FrontLeftPressure"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Wear",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"FuelData_FuelLeft\" and r._value >= 0)\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n      \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"FuelLeft\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "FuelLeft",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_FrontLeftPercentWear"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Fuel",
+      "transformations": [],
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_RACING}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "orange",
+            "mode": "continuous-YlBl"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 26
+              },
+              {
+                "color": "semi-dark-red",
+                "value": 27
+              }
+            ]
+          },
+          "unit": "pressurepsi"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "Oil"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "continuous-GrYlRd"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 7,
+        "x": 17,
+        "y": 57
+      },
+      "id": 49,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Tyre",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"EngineData_EngineOilPressure\"and r._value >= 0)\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Oil\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "Oil",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_FrontLeftPressure"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Wear",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"FuelData_FuelPressure\" and r._value >= 0)\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n      \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Fuel\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "Fuel",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_FrontLeftPercentWear"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Engine PSI",
+      "transformations": [],
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 63
+      },
+      "id": 55,
+      "panels": [],
+      "title": "Weather Distance Flags",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_RACING}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 16,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "celsius"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "Rain"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "unit",
+                "value": "humidity"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 24,
+        "x": 0,
+        "y": 64
+      },
+      "id": 31,
+      "options": {
+        "legend": {
+          "calcs": [
+            "min",
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Ambient Temp",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Conditions_Temperature_Ambient\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Ambient\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "Ambient",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_AmbientTemperature"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Track Temp",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Conditions_Temperature_Track\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Track\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "Track",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_TrackTemperature"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "hide": false,
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Conditions_RainDensity\" and r._value > 0)\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Rain Density\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "Rain"
+        }
+      ],
+      "title": "Temperature Conditions",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_RACING}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed"
+          },
+          "custom": {
+            "axisCenteredZero": true,
+            "axisColorMode": "text",
+            "axisGridShow": true,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 2,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [
+            {
+              "options": {
+                "1": {
+                  "color": "dark-green",
+                  "index": 0,
+                  "text": "Green"
+                },
+                "2": {
+                  "color": "dark-yellow",
+                  "index": 1,
+                  "text": "Yellow"
+                },
+                "4": {
+                  "color": "dark-blue",
+                  "index": 2,
+                  "text": "Blue"
+                },
+                "5": {
+                  "color": "#fbfbfb",
+                  "index": 3,
+                  "text": "White"
+                },
+                "8": {
+                  "color": "#403f3f",
+                  "index": 4,
+                  "text": "Unknown/Finish"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "max": 1,
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Flag"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "hidden"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 68
+      },
+      "id": 33,
+      "options": {
+        "barRadius": 0,
+        "barWidth": 0.97,
+        "colorByField": "Flag",
+        "fullHighlight": true,
+        "groupWidth": 0.7,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "orientation": "vertical",
+        "showValue": "never",
+        "stacking": "percent",
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        },
+        "xField": "Time",
+        "xTickLabelMaxLength": 6,
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 100
+      },
+      "pluginVersion": "10.0.2",
+      "targets": [
+        {
+          "$$hashKey": "object:24",
+          "aggregation": "Last",
+          "alias": "Flag",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "decimals": 2,
+          "displayAliasType": "Warning / Critical",
+          "displayType": "Regular",
+          "displayValueWithAlias": "Never",
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Session_Flag\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value+1.0, _time:r._time, _field:\"Flag\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_Flag"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": [],
+          "units": "none",
+          "valueHandler": "Number Threshold"
+        }
+      ],
+      "title": "Flag",
+      "transformations": [],
+      "transparent": true,
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_RACING}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "orange",
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 26
+              },
+              {
+                "color": "semi-dark-red",
+                "value": 27
+              }
+            ]
+          },
+          "unit": "lengthm"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "%"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "unit",
+                "value": "percentunit"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 68
+      },
+      "id": 56,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "alias": "Tyre",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "1s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "mqtt_consumer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"DistanceRoundTrack\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Distance\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "Distance",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "telemetry_FrontLeftPressure"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "max"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "hide": false,
+          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Track_Length\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Track Length\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+          "refId": "Track_Length"
+        }
+      ],
+      "title": "Distance in Meters",
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "%",
+            "binary": {
+              "left": "Distance",
+              "operator": "/",
+              "reducer": "sum",
+              "right": "Track Length"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        }
+      ],
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 76
+      },
+      "id": 57,
+      "panels": [],
+      "title": "Work In Progress",
+      "type": "row"
     }
+  ],
+  "refresh": false,
+  "revision": 1,
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": "Km/h",
+          "value": "3.6"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Speed",
+        "multi": false,
+        "name": "Speed",
+        "options": [
+          {
+            "selected": true,
+            "text": "Km/h",
+            "value": "3.6"
+          },
+          {
+            "selected": false,
+            "text": "MPH",
+            "value": "2.236936292054"
+          }
+        ],
+        "query": "Km/h : 3.6 , MPH : 2.236936292054",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "e Grant",
+          "value": "e Grant"
+        },
+        "datasource": {
+          "type": "influxdb",
+          "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+        },
+        "definition": "from(bucket: \"racing\")\r\n  |> range(start: -1y, stop: now())\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"Gear\")\r\n  |> keep(columns: [\"user\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> first()\r\n  |> group(columns: [])\r\n  |> drop(columns: [\"_value\",\"_time\"])",
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "User",
+        "options": [],
+        "query": "from(bucket: \"racing\")\r\n  |> range(start: -1y, stop: now())\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"Gear\")\r\n  |> keep(columns: [\"user\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> first()\r\n  |> group(columns: [])\r\n  |> drop(columns: [\"_value\",\"_time\"])",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "1689452999",
+          "value": "1689452999"
+        },
+        "datasource": {
+          "type": "influxdb",
+          "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+        },
+        "definition": "from(bucket: \"racing\")\r\n  |> range(start: -1y, stop: now())\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"CurrentLapTime\" and r._value > 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> keep(columns: [\"SessionId\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> first()\r\n  |> group(columns: [])\r\n  |> drop(columns: [\"_value\",\"_time\"])",
+        "hide": 0,
+        "includeAll": false,
+        "label": "SessionId",
+        "multi": false,
+        "name": "SessionId",
+        "options": [],
+        "query": "from(bucket: \"racing\")\r\n  |> range(start: -1y, stop: now())\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"CurrentLapTime\" and r._value > 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> keep(columns: [\"SessionId\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> first()\r\n  |> group(columns: [])\r\n  |> drop(columns: [\"_value\",\"_time\"])",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 3,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "1689431400549320400",
+          "value": "1689431400549320400"
+        },
+        "datasource": {
+          "type": "influxdb",
+          "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+        },
+        "definition": "data = from(bucket: \"racing\")\r\n  |> range(start:-1y, stop: now())\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"CurrentLapTime\" and r._value >= 0)\r\n\r\nStart = data\r\n  |> first(column: \"_time\")\r\n  |> map(fn: (r) => ({r with Start: int(v: r._time)}))\r\n  |> group()  \r\n  |> keep(columns: [\"Start\"])\r\n  |> yield()",
+        "hide": 2,
+        "includeAll": false,
+        "multi": false,
+        "name": "SessionStart",
+        "options": [],
+        "query": "data = from(bucket: \"racing\")\r\n  |> range(start:-1y, stop: now())\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"CurrentLapTime\" and r._value >= 0)\r\n\r\nStart = data\r\n  |> first(column: \"_time\")\r\n  |> map(fn: (r) => ({r with Start: int(v: r._time)}))\r\n  |> group()  \r\n  |> keep(columns: [\"Start\"])\r\n  |> yield()",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "1689432000422696200",
+          "value": "1689432000422696200"
+        },
+        "datasource": {
+          "type": "influxdb",
+          "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+        },
+        "definition": "data = from(bucket: \"racing\")\r\n  |> range(start:-1y, stop: now())\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"CurrentLapTime\" and r._value >= 0)\r\n\r\nStop = data\r\n  |> last(column: \"_time\")\r\n  |> map(fn: (r) => ({r with Stop: int(v: r._time)}))\r\n  |> group()  \r\n  |> keep(columns: [\"Stop\"])\r\n  |> yield()\r\n",
+        "hide": 2,
+        "includeAll": false,
+        "multi": false,
+        "name": "SessionEnd",
+        "options": [],
+        "query": "data = from(bucket: \"racing\")\r\n  |> range(start:-1y, stop: now())\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"CurrentLapTime\" and r._value >= 0)\r\n\r\nStop = data\r\n  |> last(column: \"_time\")\r\n  |> map(fn: (r) => ({r with Stop: int(v: r._time)}))\r\n  |> group()  \r\n  |> keep(columns: [\"Stop\"])\r\n  |> yield()\r\n",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "600",
+          "value": "600"
+        },
+        "datasource": {
+          "type": "influxdb",
+          "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+        },
+        "definition": "import \"date\"\r\nimport \"math\"\r\ndata = from(bucket: \"racing\")\r\n  |> range(start:-1y, stop: now())\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"CurrentLapTime\" and r._value >= 0)\r\nStop = data\r\n  |> last(column: \"_time\")\r\nStart = data\r\n  |> first(column: \"_time\")\r\njoin(tables: {min: Start, max: Stop}, on: [\"SessionId\"], method: \"inner\")\r\n  |> group()  \r\n  |> map(fn: (r) => ({r with Duration: math.round(x: (float(v: int(v: duration(v: uint(v: r._time_max) - uint(v: r._time_min))))/60000000000.0)*60.0)}))\r\n  |> keep(columns: [\"Duration\"])\r\n  |> yield()  ",
+        "hide": 2,
+        "includeAll": false,
+        "multi": false,
+        "name": "SessionLen",
+        "options": [],
+        "query": "import \"date\"\r\nimport \"math\"\r\ndata = from(bucket: \"racing\")\r\n  |> range(start:-1y, stop: now())\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"CurrentLapTime\" and r._value >= 0)\r\nStop = data\r\n  |> last(column: \"_time\")\r\nStart = data\r\n  |> first(column: \"_time\")\r\njoin(tables: {min: Start, max: Stop}, on: [\"SessionId\"], method: \"inner\")\r\n  |> group()  \r\n  |> map(fn: (r) => ({r with Duration: math.round(x: (float(v: int(v: duration(v: uint(v: r._time_max) - uint(v: r._time_min))))/60000000000.0)*60.0)}))\r\n  |> keep(columns: [\"Duration\"])\r\n  |> yield()  ",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": "Racing",
+          "value": "Racing"
+        },
+        "hide": 2,
+        "includeAll": false,
+        "multi": false,
+        "name": "DS_RACING",
+        "options": [],
+        "query": "influxdb",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "B4mad Session Details",
+  "uid": "e12c7ccb-ff51-4525-b5da-0d783a1019ef",
+  "version": 98,
+  "weekStart": ""
+}

--- a/manifests/base/grafana-v5/dashboards/details-extended.yaml
+++ b/manifests/base/grafana-v5/dashboards/details-extended.yaml
@@ -11,7 +11,7 @@ spec:
       datasourceName: "Racing"
   folder: CrewChief
   # resyncPeriod: 30s
-  json: >  
+json: >  
 {
   "annotations": {
     "list": [
@@ -1236,7 +1236,7 @@ spec:
             }
           ],
           "hide": false,
-          "measurement": "mqtt_consumer",
+          "measurement": "laps_cc",
           "orderByTime": "ASC",
           "policy": "default",
           "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Front_Left_BrakeTemp\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Brake\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
@@ -1278,7 +1278,7 @@ spec:
               "type": "fill"
             }
           ],
-          "measurement": "mqtt_consumer",
+          "measurement": "laps_cc",
           "orderByTime": "ASC",
           "policy": "default",
           "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Front_Left_CenterTemp\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Tyre Core\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()\r\n ",
@@ -1465,7 +1465,7 @@ spec:
               "type": "fill"
             }
           ],
-          "measurement": "mqtt_consumer",
+          "measurement": "laps_cc",
           "orderByTime": "ASC",
           "policy": "default",
           "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Front_Right_CenterTemp\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Tyre Core\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()\r\n ",
@@ -1508,7 +1508,7 @@ spec:
             }
           ],
           "hide": false,
-          "measurement": "mqtt_consumer",
+          "measurement": "laps_cc",
           "orderByTime": "ASC",
           "policy": "default",
           "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Front_Right_BrakeTemp\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Brake\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
@@ -1610,7 +1610,7 @@ spec:
               "type": "fill"
             }
           ],
-          "measurement": "mqtt_consumer",
+          "measurement": "laps_cc",
           "orderByTime": "ASC",
           "policy": "default",
           "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Session_Position_Overall\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: last, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Position\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
@@ -1712,7 +1712,7 @@ spec:
               "type": "fill"
             }
           ],
-          "measurement": "mqtt_consumer",
+          "measurement": "laps_cc",
           "orderByTime": "ASC",
           "policy": "default",
           "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Session_NumCars_Overall\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: ${SessionLen}s, fn: last, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Opponents\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
@@ -1964,7 +1964,7 @@ spec:
             }
           ],
           "hide": false,
-          "measurement": "mqtt_consumer",
+          "measurement": "laps_cc",
           "orderByTime": "ASC",
           "policy": "default",
           "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Front_Left_Pressure\" and r._value >= 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Tyre\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
@@ -2007,7 +2007,7 @@ spec:
             }
           ],
           "hide": false,
-          "measurement": "mqtt_consumer",
+          "measurement": "laps_cc",
           "orderByTime": "ASC",
           "policy": "default",
           "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Front_Left_PercentWear\" and r._value >= 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n      \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Wear\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
@@ -2295,7 +2295,7 @@ spec:
             }
           ],
           "hide": false,
-          "measurement": "mqtt_consumer",
+          "measurement": "laps_cc",
           "orderByTime": "ASC",
           "policy": "default",
           "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Front_Right_Pressure\"  and r._value >= 0)\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Tyre\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
@@ -2338,7 +2338,7 @@ spec:
             }
           ],
           "hide": false,
-          "measurement": "mqtt_consumer",
+          "measurement": "laps_cc",
           "orderByTime": "ASC",
           "policy": "default",
           "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Front_Right_PercentWear\" and r._value >= 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n      \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Wear\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
@@ -2472,7 +2472,7 @@ spec:
               "type": "fill"
             }
           ],
-          "measurement": "mqtt_consumer",
+          "measurement": "laps_cc",
           "orderByTime": "ASC",
           "policy": "default",
           "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Penalties_CutTrackWarnings\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: ${SessionLen}s, fn: max, createEmpty: false)\r\n\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Cuts\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
@@ -2572,7 +2572,7 @@ spec:
               "type": "fill"
             }
           ],
-          "measurement": "mqtt_consumer",
+          "measurement": "laps_cc",
           "orderByTime": "ASC",
           "policy": "default",
           "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Penalties_Incidents\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: ${SessionLen}s, fn: max, createEmpty: false)\r\n\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Incidents\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
@@ -2759,7 +2759,7 @@ spec:
               "type": "fill"
             }
           ],
-          "measurement": "mqtt_consumer",
+          "measurement": "laps_cc",
           "orderByTime": "ASC",
           "policy": "default",
           "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Rear_Left_CenterTemp\" and r._value >= 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Tyre Core\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()\r\n ",
@@ -2802,7 +2802,7 @@ spec:
             }
           ],
           "hide": false,
-          "measurement": "mqtt_consumer",
+          "measurement": "laps_cc",
           "orderByTime": "ASC",
           "policy": "default",
           "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Rear_Left_BrakeTemp\" and r._value >=0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Brake\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
@@ -2989,7 +2989,7 @@ spec:
               "type": "fill"
             }
           ],
-          "measurement": "mqtt_consumer",
+          "measurement": "laps_cc",
           "orderByTime": "ASC",
           "policy": "default",
           "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Rear_Right_CenterTemp\" and r._value >= 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Tyre Core\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()\r\n ",
@@ -3032,7 +3032,7 @@ spec:
             }
           ],
           "hide": false,
-          "measurement": "mqtt_consumer",
+          "measurement": "laps_cc",
           "orderByTime": "ASC",
           "policy": "default",
           "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Rear_Right_BrakeTemp\" and r._value >=0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Brake\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
@@ -3275,7 +3275,7 @@ spec:
             }
           ],
           "hide": false,
-          "measurement": "mqtt_consumer",
+          "measurement": "laps_cc",
           "orderByTime": "ASC",
           "policy": "default",
           "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Rear_Left_Pressure\" and r._value >= 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Tyre\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
@@ -3318,7 +3318,7 @@ spec:
             }
           ],
           "hide": false,
-          "measurement": "mqtt_consumer",
+          "measurement": "laps_cc",
           "orderByTime": "ASC",
           "policy": "default",
           "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Rear_Left_PercentWear\" and r._value >= 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n      \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Wear\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
@@ -3595,7 +3595,7 @@ spec:
             }
           ],
           "hide": false,
-          "measurement": "mqtt_consumer",
+          "measurement": "laps_cc",
           "orderByTime": "ASC",
           "policy": "default",
           "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Rear_Right_Pressure\" and r._value >= 0)\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Tyre\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
@@ -3638,7 +3638,7 @@ spec:
             }
           ],
           "hide": false,
-          "measurement": "mqtt_consumer",
+          "measurement": "laps_cc",
           "orderByTime": "ASC",
           "policy": "default",
           "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Rear_Right_PercentWear\"  and r._value >= 0)\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n      \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Wear\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
@@ -3772,7 +3772,7 @@ spec:
               "type": "fill"
             }
           ],
-          "measurement": "mqtt_consumer",
+          "measurement": "laps_cc",
           "orderByTime": "ASC",
           "policy": "default",
           "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Penalties_Total\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: ${SessionLen}s, fn: max, createEmpty: false)\r\n\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Penalties\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
@@ -3885,7 +3885,7 @@ spec:
             }
           ],
           "hide": false,
-          "measurement": "mqtt_consumer",
+          "measurement": "laps_cc",
           "orderByTime": "ASC",
           "policy": "default",
           "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"FuelData_FuelCapacity\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"FuelCapacity\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
@@ -3928,7 +3928,7 @@ spec:
             }
           ],
           "hide": false,
-          "measurement": "mqtt_consumer",
+          "measurement": "laps_cc",
           "orderByTime": "ASC",
           "policy": "default",
           "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"FuelData_FuelLeft\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n      \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"FuelLeft\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
@@ -4163,7 +4163,7 @@ spec:
               "type": "fill"
             }
           ],
-          "measurement": "mqtt_consumer",
+          "measurement": "laps_cc",
           "orderByTime": "ASC",
           "policy": "default",
           "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"LapTimePrevious\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Lap Valid Time\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
@@ -4206,7 +4206,7 @@ spec:
             }
           ],
           "hide": false,
-          "measurement": "mqtt_consumer",
+          "measurement": "laps_cc",
           "orderByTime": "ASC",
           "policy": "default",
           "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"CurrentLap\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Lap #\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
@@ -4304,7 +4304,7 @@ spec:
             }
           ],
           "hide": false,
-          "measurement": "mqtt_consumer",
+          "measurement": "laps_cc",
           "orderByTime": "ASC",
           "policy": "default",
           "query": "\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"SpeedMs\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1d, fn: max, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"maxspeedms\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
@@ -4342,7 +4342,7 @@ spec:
             "mode": "binary",
             "reduce": {
               "include": [
-                "mqtt_consumer.last"
+                "laps_cc.last"
               ],
               "reducer": "sum"
             },
@@ -4478,7 +4478,7 @@ spec:
               "type": "fill"
             }
           ],
-          "measurement": "mqtt_consumer",
+          "measurement": "laps_cc",
           "orderByTime": "ASC",
           "policy": "default",
           "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Session_Delta_Front\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Delta_Front\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
@@ -4521,7 +4521,7 @@ spec:
             }
           ],
           "hide": false,
-          "measurement": "mqtt_consumer",
+          "measurement": "laps_cc",
           "orderByTime": "ASC",
           "policy": "default",
           "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Session_Delta_Behind\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Delta_Behind\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
@@ -4594,8 +4594,7 @@ spec:
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -4727,7 +4726,7 @@ spec:
             }
           ],
           "hide": false,
-          "measurement": "mqtt_consumer",
+          "measurement": "laps_cc",
           "orderByTime": "ASC",
           "policy": "default",
           "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"SpeedMs\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"SpeedMs\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
@@ -4770,7 +4769,7 @@ spec:
             }
           ],
           "hide": false,
-          "measurement": "mqtt_consumer",
+          "measurement": "laps_cc",
           "orderByTime": "ASC",
           "policy": "default",
           "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"PitData_PitSpeedLimit\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"PitLimitMs\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
@@ -4817,7 +4816,7 @@ spec:
             "mode": "binary",
             "reduce": {
               "include": [
-                "mqtt_consumer.last"
+                "laps_cc.last"
               ],
               "reducer": "sum"
             },
@@ -4890,8 +4889,7 @@ spec:
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -5057,7 +5055,7 @@ spec:
             }
           ],
           "hide": false,
-          "measurement": "mqtt_consumer",
+          "measurement": "laps_cc",
           "orderByTime": "ASC",
           "policy": "autogen",
           "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Brake\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: last, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n  |> set(key: \"_field\", value: \"Brake\")\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Brake\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
@@ -5100,7 +5098,7 @@ spec:
             }
           ],
           "hide": false,
-          "measurement": "mqtt_consumer",
+          "measurement": "laps_cc",
           "orderByTime": "ASC",
           "policy": "autogen",
           "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Throttle\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: last, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n  |> set(key: \"_field\", value: \"Throttle\")\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Throttle\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
@@ -5143,7 +5141,7 @@ spec:
             }
           ],
           "hide": false,
-          "measurement": "mqtt_consumer",
+          "measurement": "laps_cc",
           "orderByTime": "ASC",
           "policy": "default",
           "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"SteeringAngle\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: last, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n  |> set(key: \"_field\", value: \"SteeringAngle\")\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"SteeringAngle\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
@@ -5186,7 +5184,7 @@ spec:
             }
           ],
           "hide": false,
-          "measurement": "mqtt_consumer",
+          "measurement": "laps_cc",
           "orderByTime": "ASC",
           "policy": "autogen",
           "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Clutch\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: last, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n  |> set(key: \"_field\", value: \"Clutch\")\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Clutch\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
@@ -5229,7 +5227,7 @@ spec:
             }
           ],
           "hide": false,
-          "measurement": "mqtt_consumer",
+          "measurement": "laps_cc",
           "orderByTime": "ASC",
           "policy": "autogen",
           "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Handbrake\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: last, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n  |> set(key: \"_field\", value: \"Handbrake\")\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Handbrake\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
@@ -5315,8 +5313,7 @@ spec:
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -5422,7 +5419,7 @@ spec:
               "type": "fill"
             }
           ],
-          "measurement": "mqtt_consumer",
+          "measurement": "laps_cc",
           "orderByTime": "ASC",
           "policy": "default",
           "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"EngineData_EngineRpm\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n  |> set(key: \"_field\", value: \"EngineData_EngineRpm\")\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"EngineData_EngineRpm\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
@@ -5465,7 +5462,7 @@ spec:
             }
           ],
           "hide": false,
-          "measurement": "mqtt_consumer",
+          "measurement": "laps_cc",
           "orderByTime": "ASC",
           "policy": "default",
           "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Gear\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: last, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n  |> set(key: \"_field\", value: \"Gear\")\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Gear\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
@@ -5508,7 +5505,7 @@ spec:
             }
           ],
           "hide": false,
-          "measurement": "mqtt_consumer",
+          "measurement": "laps_cc",
           "orderByTime": "ASC",
           "policy": "default",
           "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"EngineData_MaxEngineRpm\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n  |> set(key: \"_field\", value: \"EngineData_MaxEngineRpm\")\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"EngineData_MaxEngineRpm\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
@@ -5585,8 +5582,7 @@ spec:
             "mode": "absolute",
             "steps": [
               {
-                "color": "super-light-yellow",
-                "value": null
+                "color": "super-light-yellow"
               },
               {
                 "color": "light-blue",
@@ -5645,7 +5641,7 @@ spec:
               "type": "fill"
             }
           ],
-          "measurement": "mqtt_consumer",
+          "measurement": "laps_cc",
           "orderByTime": "ASC",
           "policy": "default",
           "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"EngineData_EngineRpm\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n  |> set(key: \"_field\", value: \"EngineData_EngineRpm\")\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"EngineData_EngineRpm\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
@@ -5688,7 +5684,7 @@ spec:
             }
           ],
           "hide": false,
-          "measurement": "mqtt_consumer",
+          "measurement": "laps_cc",
           "orderByTime": "ASC",
           "policy": "default",
           "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"EngineData_MaxEngineRpm\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n  |> set(key: \"_field\", value: \"EngineData_MaxEngineRpm\")\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"EngineData_MaxEngineRpm\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
@@ -5780,8 +5776,7 @@ spec:
             "mode": "absolute",
             "steps": [
               {
-                "color": "dark-blue",
-                "value": null
+                "color": "dark-blue"
               },
               {
                 "color": "dark-yellow",
@@ -5820,8 +5815,7 @@ spec:
                   "mode": "absolute",
                   "steps": [
                     {
-                      "color": "blue",
-                      "value": null
+                      "color": "blue"
                     },
                     {
                       "color": "light-green",
@@ -5910,7 +5904,7 @@ spec:
               "type": "fill"
             }
           ],
-          "measurement": "mqtt_consumer",
+          "measurement": "laps_cc",
           "orderByTime": "ASC",
           "policy": "default",
           "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"EngineData_EngineWaterTemp\" and r._value >=0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"EngineData_EngineWaterTemp\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()\r\n ",
@@ -5953,7 +5947,7 @@ spec:
             }
           ],
           "hide": false,
-          "measurement": "mqtt_consumer",
+          "measurement": "laps_cc",
           "orderByTime": "ASC",
           "policy": "default",
           "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"EngineData_EngineOilTemp\" and r._value >= 0)\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"EngineData_EngineOilTemp\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
@@ -6029,8 +6023,7 @@ spec:
             "mode": "absolute",
             "steps": [
               {
-                "color": "red",
-                "value": null
+                "color": "red"
               },
               {
                 "color": "green",
@@ -6087,7 +6080,7 @@ spec:
             }
           ],
           "hide": false,
-          "measurement": "mqtt_consumer",
+          "measurement": "laps_cc",
           "orderByTime": "ASC",
           "policy": "default",
           "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"FuelData_FuelCapacity\" and r._value >= 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"FuelCapacity\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
@@ -6130,7 +6123,7 @@ spec:
             }
           ],
           "hide": false,
-          "measurement": "mqtt_consumer",
+          "measurement": "laps_cc",
           "orderByTime": "ASC",
           "policy": "default",
           "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"FuelData_FuelLeft\" and r._value >= 0)\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n      \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"FuelLeft\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
@@ -6205,8 +6198,7 @@ spec:
             "mode": "absolute",
             "steps": [
               {
-                "color": "red",
-                "value": null
+                "color": "red"
               },
               {
                 "color": "green",
@@ -6282,7 +6274,7 @@ spec:
             }
           ],
           "hide": false,
-          "measurement": "mqtt_consumer",
+          "measurement": "laps_cc",
           "orderByTime": "ASC",
           "policy": "default",
           "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"EngineData_EngineOilPressure\"and r._value >= 0)\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Oil\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
@@ -6325,7 +6317,7 @@ spec:
             }
           ],
           "hide": false,
-          "measurement": "mqtt_consumer",
+          "measurement": "laps_cc",
           "orderByTime": "ASC",
           "policy": "default",
           "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"FuelData_FuelPressure\" and r._value >= 0)\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n      \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Fuel\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
@@ -6412,8 +6404,7 @@ spec:
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -6486,7 +6477,7 @@ spec:
               "type": "fill"
             }
           ],
-          "measurement": "mqtt_consumer",
+          "measurement": "laps_cc",
           "orderByTime": "ASC",
           "policy": "default",
           "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Conditions_Temperature_Ambient\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Ambient\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
@@ -6529,7 +6520,7 @@ spec:
             }
           ],
           "hide": false,
-          "measurement": "mqtt_consumer",
+          "measurement": "laps_cc",
           "orderByTime": "ASC",
           "policy": "default",
           "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Conditions_Temperature_Track\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Track\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
@@ -6634,8 +6625,7 @@ spec:
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -6718,7 +6708,7 @@ spec:
               "type": "fill"
             }
           ],
-          "measurement": "mqtt_consumer",
+          "measurement": "laps_cc",
           "orderByTime": "ASC",
           "policy": "default",
           "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Session_Flag\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value+1.0, _time:r._time, _field:\"Flag\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
@@ -6796,8 +6786,7 @@ spec:
             "mode": "absolute",
             "steps": [
               {
-                "color": "red",
-                "value": null
+                "color": "red"
               },
               {
                 "color": "green",
@@ -6871,7 +6860,7 @@ spec:
             }
           ],
           "hide": false,
-          "measurement": "mqtt_consumer",
+          "measurement": "laps_cc",
           "orderByTime": "ASC",
           "policy": "default",
           "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"DistanceRoundTrack\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Distance\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
@@ -6939,7 +6928,7 @@ spec:
       "type": "row"
     }
   ],
-  "refresh": false,
+  "refresh": "",
   "revision": 1,
   "schemaVersion": 38,
   "style": "dark",
@@ -6982,7 +6971,7 @@ spec:
         },
         "datasource": {
           "type": "influxdb",
-          "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          "uid": "${DS_RACING}"
         },
         "definition": "from(bucket: \"racing\")\r\n  |> range(start: -1y, stop: now())\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"Gear\")\r\n  |> keep(columns: [\"user\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> first()\r\n  |> group(columns: [])\r\n  |> drop(columns: [\"_value\",\"_time\"])",
         "hide": 0,
@@ -7005,7 +6994,7 @@ spec:
         },
         "datasource": {
           "type": "influxdb",
-          "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          "uid": "${DS_RACING}"
         },
         "definition": "from(bucket: \"racing\")\r\n  |> range(start: -1y, stop: now())\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"CurrentLapTime\" and r._value > 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> keep(columns: [\"SessionId\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> first()\r\n  |> group(columns: [])\r\n  |> drop(columns: [\"_value\",\"_time\"])",
         "hide": 0,
@@ -7029,7 +7018,7 @@ spec:
         },
         "datasource": {
           "type": "influxdb",
-          "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          "uid": "${DS_RACING}"
         },
         "definition": "data = from(bucket: \"racing\")\r\n  |> range(start:-1y, stop: now())\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"CurrentLapTime\" and r._value >= 0)\r\n\r\nStart = data\r\n  |> first(column: \"_time\")\r\n  |> map(fn: (r) => ({r with Start: int(v: r._time)}))\r\n  |> group()  \r\n  |> keep(columns: [\"Start\"])\r\n  |> yield()",
         "hide": 2,
@@ -7052,7 +7041,7 @@ spec:
         },
         "datasource": {
           "type": "influxdb",
-          "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          "uid": "${DS_RACING}"
         },
         "definition": "data = from(bucket: \"racing\")\r\n  |> range(start:-1y, stop: now())\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"CurrentLapTime\" and r._value >= 0)\r\n\r\nStop = data\r\n  |> last(column: \"_time\")\r\n  |> map(fn: (r) => ({r with Stop: int(v: r._time)}))\r\n  |> group()  \r\n  |> keep(columns: [\"Stop\"])\r\n  |> yield()\r\n",
         "hide": 2,
@@ -7075,7 +7064,7 @@ spec:
         },
         "datasource": {
           "type": "influxdb",
-          "uid": "b6630981-4c9c-4cb6-972b-ee25f7227619"
+          "uid": "${DS_RACING}"
         },
         "definition": "import \"date\"\r\nimport \"math\"\r\ndata = from(bucket: \"racing\")\r\n  |> range(start:-1y, stop: now())\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"CurrentLapTime\" and r._value >= 0)\r\nStop = data\r\n  |> last(column: \"_time\")\r\nStart = data\r\n  |> first(column: \"_time\")\r\njoin(tables: {min: Start, max: Stop}, on: [\"SessionId\"], method: \"inner\")\r\n  |> group()  \r\n  |> map(fn: (r) => ({r with Duration: math.round(x: (float(v: int(v: duration(v: uint(v: r._time_max) - uint(v: r._time_min))))/60000000000.0)*60.0)}))\r\n  |> keep(columns: [\"Duration\"])\r\n  |> yield()  ",
         "hide": 2,
@@ -7092,7 +7081,7 @@ spec:
       },
       {
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "Racing",
           "value": "Racing"
         },
@@ -7111,13 +7100,23 @@ spec:
     ]
   },
   "time": {
-    "from": "now-1h",
+    "from": "now-3h",
     "to": "now"
   },
-  "timepicker": {},
+  "timepicker": {
+    "refresh_intervals": [
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
   "timezone": "browser",
   "title": "B4mad Session Details",
   "uid": "e12c7ccb-ff51-4525-b5da-0d783a1019ef",
-  "version": 98,
+  "version": 101,
   "weekStart": ""
 }

--- a/manifests/base/grafana-v5/dashboards/details-extended.yaml
+++ b/manifests/base/grafana-v5/dashboards/details-extended.yaml
@@ -11,6 +11,7 @@ spec:
       datasourceName: "Racing"
   folder: CrewChief
   # resyncPeriod: 30s
+  json: >  
 {
   "annotations": {
     "list": [

--- a/manifests/base/grafana-v5/dashboards/details-extended.yaml
+++ b/manifests/base/grafana-v5/dashboards/details-extended.yaml
@@ -11,7 +11,7 @@ spec:
       datasourceName: "Racing"
   folder: CrewChief
   # resyncPeriod: 30s
-json: >  
+  json: >
 {
   "annotations": {
     "list": [
@@ -6960,14 +6960,14 @@ json: >
         ],
         "query": "Km/h : 3.6 , MPH : 2.236936292054",
         "queryValue": "",
-        "skipUrlSync": false,
+        "skipUrlSync": true,
         "type": "custom"
       },
       {
         "current": {
           "selected": false,
-          "text": "e Grant",
-          "value": "e Grant"
+          "text": "",
+          "value": ""
         },
         "datasource": {
           "type": "influxdb",
@@ -6989,8 +6989,8 @@ json: >
       {
         "current": {
           "selected": false,
-          "text": "1689452999",
-          "value": "1689452999"
+          "text": "",
+          "value": ""
         },
         "datasource": {
           "type": "influxdb",
@@ -7013,8 +7013,8 @@ json: >
       {
         "current": {
           "selected": false,
-          "text": "1689431400549320400",
-          "value": "1689431400549320400"
+          "text": "",
+          "value": ""
         },
         "datasource": {
           "type": "influxdb",
@@ -7036,8 +7036,8 @@ json: >
       {
         "current": {
           "selected": false,
-          "text": "1689432000422696200",
-          "value": "1689432000422696200"
+          "text": "",
+          "value": ""
         },
         "datasource": {
           "type": "influxdb",
@@ -7059,8 +7059,8 @@ json: >
       {
         "current": {
           "selected": false,
-          "text": "600",
-          "value": "600"
+          "text": "",
+          "value": ""
         },
         "datasource": {
           "type": "influxdb",
@@ -7081,9 +7081,9 @@ json: >
       },
       {
         "current": {
-          "selected": false,
-          "text": "Racing",
-          "value": "Racing"
+          "selected": true,
+          "text": "${DS_RACING}",
+          "value": "${DS_RACING}"
         },
         "hide": 2,
         "includeAll": false,

--- a/manifests/base/grafana-v5/dashboards/details-extended.yaml
+++ b/manifests/base/grafana-v5/dashboards/details-extended.yaml
@@ -12,7111 +12,7111 @@ spec:
   folder: CrewChief
   # resyncPeriod: 30s
   json: >
-{
-  "annotations": {
-    "list": [
-      {
-        "builtIn": 1,
-        "datasource": {
-          "type": "grafana",
-          "uid": "-- Grafana --"
-        },
-        "enable": true,
-        "hide": true,
-        "iconColor": "rgba(0, 211, 255, 1)",
-        "name": "Annotations & Alerts",
-        "target": {
-          "limit": 100,
-          "matchAny": false,
-          "tags": [],
-          "type": "dashboard"
-        },
-        "type": "dashboard"
-      }
-    ]
-  },
-  "editable": true,
-  "fiscalYearStartMonth": 0,
-  "graphTooltip": 0,
-  "id": 31,
-  "links": [],
-  "liveNow": false,
-  "panels": [
     {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 0
-      },
-      "id": 53,
-      "panels": [],
-      "title": "Session ${SessionId} for ${User} details",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "influxdb",
-        "uid": "${DS_RACING}"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "center",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "inspect": false,
-            "minWidth": 50
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": [
+      "annotations": {
+        "list": [
           {
-            "matcher": {
-              "id": "byName",
-              "options": "Duration"
+            "builtIn": 1,
+            "datasource": {
+              "type": "grafana",
+              "uid": "-- Grafana --"
             },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "m"
-              },
-              {
-                "id": "custom.width",
-                "value": 124
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Game"
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "target": {
+              "limit": 100,
+              "matchAny": false,
+              "tags": [],
+              "type": "dashboard"
             },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 209
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Session Type"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 110
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Duration"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "clockms"
-              },
-              {
-                "id": "decimals",
-                "value": 2
-              },
-              {
-                "id": "custom.width",
-                "value": 200
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Track"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 204
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Stop"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 167
-              },
-              {
-                "id": "unit",
-                "value": "dateTimeFromNow"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Start"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 154
-              },
-              {
-                "id": "unit",
-                "value": "dateTimeFromNow"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Car Model"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 153
-              }
-            ]
+            "type": "dashboard"
           }
         ]
       },
-      "gridPos": {
-        "h": 4,
-        "w": 24,
-        "x": 0,
-        "y": 1
-      },
-      "id": 54,
-      "options": {
-        "cellHeight": "sm",
-        "footer": {
-          "countRows": false,
-          "fields": "",
-          "reducer": [
-            "sum"
-          ],
-          "show": false
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 0,
+      "id": 31,
+      "links": [],
+      "liveNow": false,
+      "panels": [
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 53,
+          "panels": [],
+          "title": "Session ${SessionId} for ${User} details",
+          "type": "row"
         },
-        "showHeader": true,
-        "sortBy": []
-      },
-      "pluginVersion": "10.0.2",
-      "targets": [
         {
           "datasource": {
             "type": "influxdb",
             "uid": "${DS_RACING}"
           },
-          "query": "import \"date\"\r\nfields = [\"_time\", \"GameName\", \"user\", \"CarModel\", \"TrackCode\", \"SessionId\", \"SessionTypeName\"]\r\njfields = [\"GameName\", \"user\", \"CarModel\", \"TrackCode\", \"SessionId\", \"SessionTypeName\"]\r\n\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\ndata = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"CurrentLapTime\")\r\n  |> keep(columns: fields)\r\n\r\nmin = data\r\n  |> first(column: \"_time\")\r\n\r\nmax = data\r\n  |> last(column: \"_time\")\r\n\r\njoin(tables: {min: min, max: max}, on: jfields, method: \"inner\")\r\n  |> group()  \r\n  \r\n  |> drop(columns: [\"SessionId\",  \"user\" ])\r\n  |> yield()",
-          "refId": "A"
-        }
-      ],
-      "title": "Session Info",
-      "transformations": [
-        {
-          "id": "organize",
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "center",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "inspect": false,
+                "minWidth": 50
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Duration"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "m"
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 124
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Game"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 209
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Session Type"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 110
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Duration"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "clockms"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 200
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Track"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 204
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Stop"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 167
+                  },
+                  {
+                    "id": "unit",
+                    "value": "dateTimeFromNow"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Start"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 154
+                  },
+                  {
+                    "id": "unit",
+                    "value": "dateTimeFromNow"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Car Model"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 153
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 24,
+            "x": 0,
+            "y": 1
+          },
+          "id": 54,
           "options": {
-            "excludeByName": {
-              "Duration": true
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
             },
-            "indexByName": {
-              "CarModel": 4,
-              "Duration": 3,
-              "GameName": 5,
-              "SessionId": 8,
-              "SessionType": 7,
-              "TrackCode": 6,
-              "_time_max": 2,
-              "_time_min": 1,
-              "user": 0
-            },
-            "renameByName": {
-              "CarModel": "Car Model",
-              "Duration": "",
-              "GameName": "Game",
-              "SessionTypeName": "Session Type",
-              "TrackCode": "Track",
-              "_time_max": "Stop",
-              "_time_min": "Start",
-              "user": "User"
+            "showHeader": true,
+            "sortBy": []
+          },
+          "pluginVersion": "10.0.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "query": "import \"date\"\r\nfields = [\"_time\", \"GameName\", \"user\", \"CarModel\", \"TrackCode\", \"SessionId\", \"SessionTypeName\"]\r\njfields = [\"GameName\", \"user\", \"CarModel\", \"TrackCode\", \"SessionId\", \"SessionTypeName\"]\r\n\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\ndata = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"CurrentLapTime\")\r\n  |> keep(columns: fields)\r\n\r\nmin = data\r\n  |> first(column: \"_time\")\r\n\r\nmax = data\r\n  |> last(column: \"_time\")\r\n\r\njoin(tables: {min: min, max: max}, on: jfields, method: \"inner\")\r\n  |> group()  \r\n  \r\n  |> drop(columns: [\"SessionId\",  \"user\" ])\r\n  |> yield()",
+              "refId": "A"
             }
-          }
-        },
-        {
-          "id": "calculateField",
-          "options": {
-            "alias": "Duration",
-            "binary": {
-              "left": "Stop",
-              "operator": "-",
-              "reducer": "sum",
-              "right": "Start"
-            },
-            "mode": "binary",
-            "reduce": {
-              "reducer": "sum"
-            }
-          }
-        }
-      ],
-      "type": "table"
-    },
-    {
-      "datasource": {
-        "type": "influxdb",
-        "uid": "${DS_RACING}"
-      },
-      "description": "Times are base only in valid laps.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "center",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "filterable": false,
-            "inspect": false,
-            "minWidth": 50
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Track"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "lengthm"
-              },
-              {
-                "id": "custom.width",
-                "value": 82
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Odometer"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "lengthm"
-              },
-              {
-                "id": "custom.width",
-                "value": 84
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Avg Lap Time"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "clocks"
-              },
-              {
-                "id": "custom.width",
-                "value": 125
-              },
-              {
-                "id": "decimals",
-                "value": 2
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Max Lap Time"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "clocks"
-              },
-              {
-                "id": "custom.width",
-                "value": 128
-              },
-              {
-                "id": "decimals",
-                "value": 2
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Top(Km/h)"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "Speed"
-              },
-              {
-                "id": "decimals",
-                "value": 1
-              },
-              {
-                "id": "custom.width",
-                "value": 104
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Avg(Km/h)"
-            },
-            "properties": [
-              {
-                "id": "decimals",
-                "value": 1
-              },
-              {
-                "id": "unit",
-                "value": "Speed"
-              },
-              {
-                "id": "custom.width",
-                "value": 103
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Total"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 72
-              },
-              {
-                "id": "unit",
-                "value": "Laps"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Avg/Max"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "s"
-              },
-              {
-                "id": "decimals",
-                "value": 3
-              },
-              {
-                "id": "custom.width",
-                "value": 103
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "P.Top"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 58
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "P.Low"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 56
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Fuel Used"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "litre"
-              },
-              {
-                "id": "custom.width",
-                "value": 88
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Fuel/Lap "
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "litre"
-              },
-              {
-                "id": "custom.width",
-                "value": 81
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Fuel Left "
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 76
-              },
-              {
-                "id": "unit",
-                "value": "litre"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Best Lap Time"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 134
-              },
-              {
-                "id": "unit",
-                "value": "clocks"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "AVG/Best"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 81
-              },
-              {
-                "id": "unit",
-                "value": "s"
-              },
-              {
-                "id": "decimals",
-                "value": 3
-              },
-              {
-                "id": "color",
-                "value": {
-                  "mode": "thresholds"
+          ],
+          "title": "Session Info",
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Duration": true
+                },
+                "indexByName": {
+                  "CarModel": 4,
+                  "Duration": 3,
+                  "GameName": 5,
+                  "SessionId": 8,
+                  "SessionType": 7,
+                  "TrackCode": 6,
+                  "_time_max": 2,
+                  "_time_min": 1,
+                  "user": 0
+                },
+                "renameByName": {
+                  "CarModel": "Car Model",
+                  "Duration": "",
+                  "GameName": "Game",
+                  "SessionTypeName": "Session Type",
+                  "TrackCode": "Track",
+                  "_time_max": "Stop",
+                  "_time_min": "Start",
+                  "user": "User"
                 }
+              }
+            },
+            {
+              "id": "calculateField",
+              "options": {
+                "alias": "Duration",
+                "binary": {
+                  "left": "Stop",
+                  "operator": "-",
+                  "reducer": "sum",
+                  "right": "Start"
+                },
+                "mode": "binary",
+                "reduce": {
+                  "reducer": "sum"
+                }
+              }
+            }
+          ],
+          "type": "table"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "description": "Times are base only in valid laps.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "center",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "filterable": false,
+                "inspect": false,
+                "minWidth": 50
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Track"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "lengthm"
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 82
+                  }
+                ]
               },
               {
-                "id": "thresholds",
-                "value": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "text",
-                      "value": null
-                    },
-                    {
-                      "color": "green",
-                      "value": -0.01
-                    },
-                    {
-                      "color": "dark-red",
-                      "value": 0.01
+                "matcher": {
+                  "id": "byName",
+                  "options": "Odometer"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "lengthm"
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 84
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Avg Lap Time"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "clocks"
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 125
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Max Lap Time"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "clocks"
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 128
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Top(Km/h)"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "Speed"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 1
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 104
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Avg(Km/h)"
+                },
+                "properties": [
+                  {
+                    "id": "decimals",
+                    "value": 1
+                  },
+                  {
+                    "id": "unit",
+                    "value": "Speed"
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 103
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Total"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 72
+                  },
+                  {
+                    "id": "unit",
+                    "value": "Laps"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Avg/Max"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "s"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 3
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 103
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "P.Top"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 58
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "P.Low"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 56
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Fuel Used"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "litre"
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 88
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Fuel/Lap "
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "litre"
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 81
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Fuel Left "
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 76
+                  },
+                  {
+                    "id": "unit",
+                    "value": "litre"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Best Lap Time"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 134
+                  },
+                  {
+                    "id": "unit",
+                    "value": "clocks"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "AVG/Best"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 81
+                  },
+                  {
+                    "id": "unit",
+                    "value": "s"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 3
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "mode": "thresholds"
                     }
-                  ]
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 24,
-        "x": 0,
-        "y": 5
-      },
-      "id": 60,
-      "options": {
-        "cellHeight": "sm",
-        "footer": {
-          "countRows": false,
-          "fields": [],
-          "reducer": [
-            "changeCount"
-          ],
-          "show": false
-        },
-        "frameIndex": 6,
-        "showHeader": true,
-        "sortBy": []
-      },
-      "pluginVersion": "10.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "query": "import \"date\"\r\nFinalOutput = [\"SessionId\", \"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"CurrentLap\" and r._value > 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1d, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value,  _time:r._time, _field:\"Total Laps\"}))\r\n  |> sort(columns: [\"_value\"], desc: false)\r\n  \r\n  |> keep(columns:FinalOutput)\r\n  \r\nNamedSeries |> yield()",
-          "refId": "Total Laps"
-        },
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "hide": false,
-          "query": "import \"date\"\r\nFinalOutput = [\"SessionId\", \"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Track_Length\" and r._value >= 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1d, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value,  _time:r._time, _field:\"Track_Length\"}))\r\n  |> keep(columns:FinalOutput)\r\nNamedSeries |> yield()",
-          "refId": "Track"
-        },
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "hide": false,
-          "query": "import \"date\"\r\nFinalOutput = [\"SessionId\", \"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"LapTimePrevious\" and r._value > 0)\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1d, fn: mean, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Avg Lap Time\"}))\r\n  |> keep(columns:FinalOutput)\r\nNamedSeries |> yield()",
-          "refId": "Laps"
-        },
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "hide": false,
-          "query": "import \"date\"\r\nFinalOutput = [\"SessionId\", \"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"CurrentLapTime\" and r._value > 0)\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1d, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Max Lap Time\"}))\r\n  |> keep(columns:FinalOutput)\r\nNamedSeries |> yield()",
-          "refId": "MaxLap"
-        },
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "hide": false,
-          "query": "import \"date\"\r\nFinalOutput = [\"SessionId\", \"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"SpeedMs\" and r._value > 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1d, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Top Speed ms\"}))\r\n  |> keep(columns:FinalOutput)\r\nNamedSeries |> yield()",
-          "refId": "Top Speed"
-        },
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "hide": false,
-          "query": "import \"date\"\r\nFinalOutput = [\"SessionId\", \"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"SpeedMs\" and r._value > 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1d, fn: mean, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Avg Speed ms\"}))\r\n  |> keep(columns:FinalOutput)\r\nNamedSeries |> yield()",
-          "refId": "AVG Speed"
-        },
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "hide": false,
-          "query": "import \"date\"\r\nFinalOutput = [\"SessionId\", \"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Session_Position_Overall\" and r._value > 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1d, fn: min, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"P.Top\"}))\r\n  |> keep(columns:FinalOutput)\r\nNamedSeries |> yield()",
-          "refId": "Top"
-        },
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "hide": false,
-          "query": "import \"date\"\r\nFinalOutput = [\"SessionId\", \"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Session_Position_Overall\" and r._value > 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1d, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"P.Low\"}))\r\n  |> keep(columns:FinalOutput)\r\nNamedSeries |> yield()",
-          "refId": "Low"
-        },
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "hide": false,
-          "query": "import \"date\"\r\nFinalOutput = [\"SessionId\", \"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"FuelData_FuelLeft\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1d, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"MaxFuel\"}))\r\n  |> keep(columns:FinalOutput)\r\nNamedSeries |> yield()",
-          "refId": "FuelMax"
-        },
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "hide": false,
-          "query": "import \"date\"\r\nFinalOutput = [\"SessionId\", \"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"FuelData_FuelLeft\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1d, fn: min, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"MinFuel\"}))\r\n  |> keep(columns:FinalOutput)\r\nNamedSeries |> yield()",
-          "refId": "FuelLeft"
-        },
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "hide": false,
-          "query": "import \"date\"\r\nFinalOutput = [\"SessionId\", \"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Session_PlayerClassSessionBestLapTime\" and r._value >= 0)\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1d, fn: min, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Best Lap Time\"}))\r\n  |> keep(columns:FinalOutput)\r\nNamedSeries |> yield()",
-          "refId": "BestLap"
-        }
-      ],
-      "title": "Session Stats",
-      "transformations": [
-        {
-          "id": "joinByField",
-          "options": {
-            "byField": "Time",
-            "mode": "outer"
-          }
-        },
-        {
-          "id": "calculateField",
-          "options": {
-            "alias": "Distance",
-            "binary": {
-              "left": "Total Laps",
-              "operator": "*",
-              "reducer": "sum",
-              "right": "Track_Length"
-            },
-            "mode": "binary",
-            "reduce": {
-              "reducer": "sum"
-            }
-          }
-        },
-        {
-          "id": "calculateField",
-          "options": {
-            "alias": "Avg/Max",
-            "binary": {
-              "left": "Avg Lap Time",
-              "operator": "-",
-              "reducer": "sum",
-              "right": "Max Lap Time"
-            },
-            "mode": "binary",
-            "reduce": {
-              "reducer": "sum"
-            }
-          }
-        },
-        {
-          "id": "calculateField",
-          "options": {
-            "alias": "AVG/Best",
-            "binary": {
-              "left": "Avg Lap Time",
-              "operator": "-",
-              "reducer": "sum",
-              "right": "Best Lap Time"
-            },
-            "mode": "binary",
-            "reduce": {
-              "reducer": "sum"
-            }
-          }
-        },
-        {
-          "id": "calculateField",
-          "options": {
-            "alias": "Top(${Speed:text})",
-            "binary": {
-              "left": "Top Speed ms",
-              "operator": "*",
-              "reducer": "sum",
-              "right": "${Speed}"
-            },
-            "mode": "binary",
-            "reduce": {
-              "reducer": "sum"
-            }
-          }
-        },
-        {
-          "id": "calculateField",
-          "options": {
-            "alias": "Avg(${Speed:text})",
-            "binary": {
-              "left": "Avg Speed ms",
-              "operator": "*",
-              "reducer": "sum",
-              "right": "${Speed}"
-            },
-            "mode": "binary",
-            "reduce": {
-              "reducer": "sum"
-            }
-          }
-        },
-        {
-          "id": "calculateField",
-          "options": {
-            "alias": "Fuel Used",
-            "binary": {
-              "left": "MinFuel",
-              "operator": "-",
-              "reducer": "sum",
-              "right": "MaxFuel"
-            },
-            "mode": "binary",
-            "reduce": {
-              "reducer": "sum"
-            }
-          }
-        },
-        {
-          "id": "calculateField",
-          "options": {
-            "alias": "Fuel/Lap ",
-            "binary": {
-              "left": "Fuel Used",
-              "operator": "/",
-              "reducer": "sum",
-              "right": "Total Laps"
-            },
-            "mode": "binary",
-            "reduce": {
-              "reducer": "sum"
-            }
-          }
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Avg Speed ms": true,
-              "MaxFuel": true,
-              "MinFuel": false,
-              "Time": true,
-              "Top Speed ms": true
-            },
-            "indexByName": {
-              "AVG/Best": 10,
-              "Avg Lap Time": 6,
-              "Avg Speed ms": 12,
-              "Avg/Max": 9,
-              "Best Lap Time": 7,
-              "Distance": 5,
-              "Fuel Used": 14,
-              "Fuel/Lap ": 15,
-              "Max Lap Time": 8,
-              "MaxFuel": 13,
-              "MinFuel": 16,
-              "P.Low": 3,
-              "P.Top": 2,
-              "Time": 0,
-              "Top Speed ms": 11,
-              "Total Laps": 1,
-              "Track_Length": 4
-            },
-            "renameByName": {
-              "Distance": "Odometer",
-              "MinFuel": "Fuel Left ",
-              "Total Laps": "Total",
-              "Track_Length": "Track"
-            }
-          }
-        }
-      ],
-      "type": "table"
-    },
-    {
-      "datasource": {
-        "type": "influxdb",
-        "uid": "${DS_RACING}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "center",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "filterable": false,
-            "inspect": false,
-            "minWidth": 50
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Track Length"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "lengthm"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "CurrentLapTime"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "s"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "CarNumber"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 95
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "CountryCode"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 69
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "iRating"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 76
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Driver"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 144
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 11,
-        "x": 0,
-        "y": 9
-      },
-      "id": 58,
-      "options": {
-        "cellHeight": "sm",
-        "footer": {
-          "countRows": false,
-          "fields": "",
-          "reducer": [
-            "sum"
-          ],
-          "show": false
-        },
-        "frameIndex": 1,
-        "showHeader": true,
-        "sortBy": []
-      },
-      "pluginVersion": "10.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "query": "import \"influxdata/influxdb/schema\"\r\nfrom(bucket: \"racing\")\r\n  |> range(start: -1y, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> filter(fn: (r) => r[\"_field\"] =~ /^(Session_CarNumber|Session_iRating|Session_StrengthOfField)$/)\r\n  |> limit(n:1)\r\n  |> schema.fieldsAsCols() \r\n  |> drop(columns: [\"GameName\",  \"CarModel\", \"_time\", \"TrackCode\", \"SessionId\", \"_start\",\"_stop\", \"SessionTypeName\", \"_measurement\", \"host\", \"topic\", \"UserId\", \"user\" ])\r\n  |> group(columns: [])  \r\n\r\n \r\n  \r\n\r\n\r\n",
-          "refId": "A"
-        }
-      ],
-      "transformations": [
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {},
-            "indexByName": {
-              "CountryCode": 2,
-              "Driver": 1,
-              "Session_CarNumber": 0,
-              "Session_iRating": 4,
-              "Team": 3
-            },
-            "renameByName": {
-              "Duration": "Minutes",
-              "Session_CarNumber": "CarNumber",
-              "Session_StrengthOfField": "Strength Of Field",
-              "Session_iRating": "iRating",
-              "Track_Length": "Track Length",
-              "_time_max": "Stop",
-              "_time_min": "Start",
-              "_value": "Car Number",
-              "user": "User"
-            }
-          }
-        }
-      ],
-      "transparent": true,
-      "type": "table"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 12
-      },
-      "id": 11,
-      "panels": [],
-      "title": "Tyres Position Penalties",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "influxdb",
-        "uid": "${DS_RACING}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "yellow",
-            "mode": "thresholds"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 40,
-            "gradientMode": "hue",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "area"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "dark-blue",
-                "value": null
-              },
-              {
-                "color": "dark-yellow",
-                "value": 70
-              },
-              {
-                "color": "dark-green",
-                "value": 80
-              },
-              {
-                "color": "dark-orange",
-                "value": 90
-              },
-              {
-                "color": "dark-red",
-                "value": 100
-              }
-            ]
-          },
-          "unit": "celsius"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byFrameRefID",
-              "options": "BrakeTemp"
-            },
-            "properties": [
-              {
-                "id": "custom.axisPlacement",
-                "value": "right"
-              },
-              {
-                "id": "thresholds",
-                "value": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "light-blue",
-                      "value": null
-                    },
-                    {
-                      "color": "light-green",
-                      "value": 350
-                    },
-                    {
-                      "color": "light-red",
-                      "value": 650
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "text",
+                          "value": null
+                        },
+                        {
+                          "color": "green",
+                          "value": -0.01
+                        },
+                        {
+                          "color": "dark-red",
+                          "value": 0.01
+                        }
+                      ]
                     }
-                  ]
-                }
-              },
-              {
-                "id": "custom.scaleDistribution",
-                "value": {
-                  "type": "linear"
-                }
-              },
-              {
-                "id": "custom.thresholdsStyle",
-                "value": {
-                  "mode": "dashed"
-                }
-              },
-              {
-                "id": "custom.fillOpacity",
-                "value": 0
+                  }
+                ]
               }
             ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 5,
-        "x": 0,
-        "y": 13
-      },
-      "id": 41,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "alias": "Brake",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
           },
-          "groupBy": [
-            {
-              "params": [
-                "1s"
+          "gridPos": {
+            "h": 4,
+            "w": 24,
+            "x": 0,
+            "y": 5
+          },
+          "id": 60,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": [],
+              "reducer": [
+                "changeCount"
               ],
-              "type": "time"
+              "show": false
+            },
+            "frameIndex": 6,
+            "showHeader": true,
+            "sortBy": []
+          },
+          "pluginVersion": "10.0.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "query": "import \"date\"\r\nFinalOutput = [\"SessionId\", \"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"CurrentLap\" and r._value > 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1d, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value,  _time:r._time, _field:\"Total Laps\"}))\r\n  |> sort(columns: [\"_value\"], desc: false)\r\n  \r\n  |> keep(columns:FinalOutput)\r\n  \r\nNamedSeries |> yield()",
+              "refId": "Total Laps"
             },
             {
-              "params": [
-                "0"
-              ],
-              "type": "fill"
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "hide": false,
+              "query": "import \"date\"\r\nFinalOutput = [\"SessionId\", \"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Track_Length\" and r._value >= 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1d, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value,  _time:r._time, _field:\"Track_Length\"}))\r\n  |> keep(columns:FinalOutput)\r\nNamedSeries |> yield()",
+              "refId": "Track"
+            },
+            {
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "hide": false,
+              "query": "import \"date\"\r\nFinalOutput = [\"SessionId\", \"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"LapTimePrevious\" and r._value > 0)\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1d, fn: mean, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Avg Lap Time\"}))\r\n  |> keep(columns:FinalOutput)\r\nNamedSeries |> yield()",
+              "refId": "Laps"
+            },
+            {
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "hide": false,
+              "query": "import \"date\"\r\nFinalOutput = [\"SessionId\", \"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"CurrentLapTime\" and r._value > 0)\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1d, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Max Lap Time\"}))\r\n  |> keep(columns:FinalOutput)\r\nNamedSeries |> yield()",
+              "refId": "MaxLap"
+            },
+            {
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "hide": false,
+              "query": "import \"date\"\r\nFinalOutput = [\"SessionId\", \"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"SpeedMs\" and r._value > 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1d, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Top Speed ms\"}))\r\n  |> keep(columns:FinalOutput)\r\nNamedSeries |> yield()",
+              "refId": "Top Speed"
+            },
+            {
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "hide": false,
+              "query": "import \"date\"\r\nFinalOutput = [\"SessionId\", \"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"SpeedMs\" and r._value > 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1d, fn: mean, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Avg Speed ms\"}))\r\n  |> keep(columns:FinalOutput)\r\nNamedSeries |> yield()",
+              "refId": "AVG Speed"
+            },
+            {
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "hide": false,
+              "query": "import \"date\"\r\nFinalOutput = [\"SessionId\", \"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Session_Position_Overall\" and r._value > 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1d, fn: min, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"P.Top\"}))\r\n  |> keep(columns:FinalOutput)\r\nNamedSeries |> yield()",
+              "refId": "Top"
+            },
+            {
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "hide": false,
+              "query": "import \"date\"\r\nFinalOutput = [\"SessionId\", \"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Session_Position_Overall\" and r._value > 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1d, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"P.Low\"}))\r\n  |> keep(columns:FinalOutput)\r\nNamedSeries |> yield()",
+              "refId": "Low"
+            },
+            {
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "hide": false,
+              "query": "import \"date\"\r\nFinalOutput = [\"SessionId\", \"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"FuelData_FuelLeft\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1d, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"MaxFuel\"}))\r\n  |> keep(columns:FinalOutput)\r\nNamedSeries |> yield()",
+              "refId": "FuelMax"
+            },
+            {
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "hide": false,
+              "query": "import \"date\"\r\nFinalOutput = [\"SessionId\", \"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"FuelData_FuelLeft\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1d, fn: min, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"MinFuel\"}))\r\n  |> keep(columns:FinalOutput)\r\nNamedSeries |> yield()",
+              "refId": "FuelLeft"
+            },
+            {
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "hide": false,
+              "query": "import \"date\"\r\nFinalOutput = [\"SessionId\", \"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Session_PlayerClassSessionBestLapTime\" and r._value >= 0)\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1d, fn: min, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Best Lap Time\"}))\r\n  |> keep(columns:FinalOutput)\r\nNamedSeries |> yield()",
+              "refId": "BestLap"
             }
           ],
-          "hide": false,
-          "measurement": "laps_cc",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Front_Left_BrakeTemp\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Brake\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-          "refId": "BrakeTemp",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "telemetry_TyreData_Front_Left_BrakeTemp"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "max"
-              }
-            ]
-          ],
-          "tags": []
-        },
-        {
-          "alias": "Core",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "groupBy": [
+          "title": "Session Stats",
+          "transformations": [
             {
-              "params": [
-                "1s"
-              ],
-              "type": "time"
+              "id": "joinByField",
+              "options": {
+                "byField": "Time",
+                "mode": "outer"
+              }
             },
             {
-              "params": [
-                "0"
-              ],
-              "type": "fill"
-            }
-          ],
-          "measurement": "laps_cc",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Front_Left_CenterTemp\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Tyre Core\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()\r\n ",
-          "refId": "TyreCore",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "telemetry_TyreData_Front_Left_CenterTemp"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "max"
-              }
-            ]
-          ],
-          "tags": []
-        }
-      ],
-      "title": "Front Left Temp",
-      "transformations": [],
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "influxdb",
-        "uid": "${DS_RACING}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "yellow",
-            "mode": "thresholds"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 40,
-            "gradientMode": "hue",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "area"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "dark-blue",
-                "value": null
-              },
-              {
-                "color": "dark-yellow",
-                "value": 70
-              },
-              {
-                "color": "dark-green",
-                "value": 80
-              },
-              {
-                "color": "dark-orange",
-                "value": 90
-              },
-              {
-                "color": "dark-red",
-                "value": 100
-              }
-            ]
-          },
-          "unit": "celsius"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byFrameRefID",
-              "options": "BrakeTemp"
-            },
-            "properties": [
-              {
-                "id": "custom.axisPlacement",
-                "value": "right"
-              },
-              {
-                "id": "thresholds",
-                "value": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "light-blue",
-                      "value": null
-                    },
-                    {
-                      "color": "light-green",
-                      "value": 350
-                    },
-                    {
-                      "color": "light-red",
-                      "value": 650
-                    }
-                  ]
+              "id": "calculateField",
+              "options": {
+                "alias": "Distance",
+                "binary": {
+                  "left": "Total Laps",
+                  "operator": "*",
+                  "reducer": "sum",
+                  "right": "Track_Length"
+                },
+                "mode": "binary",
+                "reduce": {
+                  "reducer": "sum"
                 }
-              },
-              {
-                "id": "custom.scaleDistribution",
-                "value": {
-                  "type": "linear"
-                }
-              },
-              {
-                "id": "custom.thresholdsStyle",
-                "value": {
-                  "mode": "dashed"
-                }
-              },
-              {
-                "id": "custom.fillOpacity",
-                "value": 0
               }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 5,
-        "x": 5,
-        "y": 13
-      },
-      "id": 36,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "alias": "Core",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "1s"
-              ],
-              "type": "time"
             },
             {
-              "params": [
-                "0"
-              ],
-              "type": "fill"
-            }
-          ],
-          "measurement": "laps_cc",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Front_Right_CenterTemp\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Tyre Core\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()\r\n ",
-          "refId": "TyreCore",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "telemetry_TyreData_Front_Left_CenterTemp"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "max"
+              "id": "calculateField",
+              "options": {
+                "alias": "Avg/Max",
+                "binary": {
+                  "left": "Avg Lap Time",
+                  "operator": "-",
+                  "reducer": "sum",
+                  "right": "Max Lap Time"
+                },
+                "mode": "binary",
+                "reduce": {
+                  "reducer": "sum"
+                }
               }
-            ]
-          ],
-          "tags": []
-        },
-        {
-          "alias": "Brake",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "1s"
-              ],
-              "type": "time"
             },
             {
-              "params": [
-                "0"
-              ],
-              "type": "fill"
+              "id": "calculateField",
+              "options": {
+                "alias": "AVG/Best",
+                "binary": {
+                  "left": "Avg Lap Time",
+                  "operator": "-",
+                  "reducer": "sum",
+                  "right": "Best Lap Time"
+                },
+                "mode": "binary",
+                "reduce": {
+                  "reducer": "sum"
+                }
+              }
+            },
+            {
+              "id": "calculateField",
+              "options": {
+                "alias": "Top(${Speed:text})",
+                "binary": {
+                  "left": "Top Speed ms",
+                  "operator": "*",
+                  "reducer": "sum",
+                  "right": "${Speed}"
+                },
+                "mode": "binary",
+                "reduce": {
+                  "reducer": "sum"
+                }
+              }
+            },
+            {
+              "id": "calculateField",
+              "options": {
+                "alias": "Avg(${Speed:text})",
+                "binary": {
+                  "left": "Avg Speed ms",
+                  "operator": "*",
+                  "reducer": "sum",
+                  "right": "${Speed}"
+                },
+                "mode": "binary",
+                "reduce": {
+                  "reducer": "sum"
+                }
+              }
+            },
+            {
+              "id": "calculateField",
+              "options": {
+                "alias": "Fuel Used",
+                "binary": {
+                  "left": "MinFuel",
+                  "operator": "-",
+                  "reducer": "sum",
+                  "right": "MaxFuel"
+                },
+                "mode": "binary",
+                "reduce": {
+                  "reducer": "sum"
+                }
+              }
+            },
+            {
+              "id": "calculateField",
+              "options": {
+                "alias": "Fuel/Lap ",
+                "binary": {
+                  "left": "Fuel Used",
+                  "operator": "/",
+                  "reducer": "sum",
+                  "right": "Total Laps"
+                },
+                "mode": "binary",
+                "reduce": {
+                  "reducer": "sum"
+                }
+              }
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Avg Speed ms": true,
+                  "MaxFuel": true,
+                  "MinFuel": false,
+                  "Time": true,
+                  "Top Speed ms": true
+                },
+                "indexByName": {
+                  "AVG/Best": 10,
+                  "Avg Lap Time": 6,
+                  "Avg Speed ms": 12,
+                  "Avg/Max": 9,
+                  "Best Lap Time": 7,
+                  "Distance": 5,
+                  "Fuel Used": 14,
+                  "Fuel/Lap ": 15,
+                  "Max Lap Time": 8,
+                  "MaxFuel": 13,
+                  "MinFuel": 16,
+                  "P.Low": 3,
+                  "P.Top": 2,
+                  "Time": 0,
+                  "Top Speed ms": 11,
+                  "Total Laps": 1,
+                  "Track_Length": 4
+                },
+                "renameByName": {
+                  "Distance": "Odometer",
+                  "MinFuel": "Fuel Left ",
+                  "Total Laps": "Total",
+                  "Track_Length": "Track"
+                }
+              }
             }
           ],
-          "hide": false,
-          "measurement": "laps_cc",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Front_Right_BrakeTemp\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Brake\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-          "refId": "BrakeTemp",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "telemetry_TyreData_Front_Left_BrakeTemp"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "max"
-              }
-            ]
-          ],
-          "tags": []
-        }
-      ],
-      "title": "Front Right Temp",
-      "transformations": [],
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "influxdb",
-        "uid": "${DS_RACING}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "continuous-RdYlGr"
-          },
-          "decimals": 0,
-          "mappings": [],
-          "min": 1,
-          "noValue": "0",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
+          "type": "table"
         },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 2,
-        "x": 10,
-        "y": 13
-      },
-      "id": 22,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "center",
-        "orientation": "vertical",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "text": {
-          "titleSize": 1
-        },
-        "textMode": "value"
-      },
-      "pluginVersion": "10.0.2",
-      "targets": [
         {
           "datasource": {
             "type": "influxdb",
             "uid": "${DS_RACING}"
           },
-          "groupBy": [
-            {
-              "params": [
-                "1s"
-              ],
-              "type": "time"
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "center",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "filterable": false,
+                "inspect": false,
+                "minWidth": 50
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
             },
-            {
-              "params": [
-                "null"
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Track Length"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "lengthm"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "CurrentLapTime"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "s"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "CarNumber"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 95
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "CountryCode"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 69
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "iRating"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 76
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Driver"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 144
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 11,
+            "x": 0,
+            "y": 9
+          },
+          "id": 58,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": [
+                "sum"
               ],
-              "type": "fill"
+              "show": false
+            },
+            "frameIndex": 1,
+            "showHeader": true,
+            "sortBy": []
+          },
+          "pluginVersion": "10.0.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "query": "import \"influxdata/influxdb/schema\"\r\nfrom(bucket: \"racing\")\r\n  |> range(start: -1y, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> filter(fn: (r) => r[\"_field\"] =~ /^(Session_CarNumber|Session_iRating|Session_StrengthOfField)$/)\r\n  |> limit(n:1)\r\n  |> schema.fieldsAsCols() \r\n  |> drop(columns: [\"GameName\",  \"CarModel\", \"_time\", \"TrackCode\", \"SessionId\", \"_start\",\"_stop\", \"SessionTypeName\", \"_measurement\", \"host\", \"topic\", \"UserId\", \"user\" ])\r\n  |> group(columns: [])  \r\n\r\n \r\n  \r\n\r\n\r\n",
+              "refId": "A"
             }
           ],
-          "measurement": "laps_cc",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Session_Position_Overall\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: last, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Position\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "telemetry_Session_Position_Overall"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "last"
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {},
+                "indexByName": {
+                  "CountryCode": 2,
+                  "Driver": 1,
+                  "Session_CarNumber": 0,
+                  "Session_iRating": 4,
+                  "Team": 3
+                },
+                "renameByName": {
+                  "Duration": "Minutes",
+                  "Session_CarNumber": "CarNumber",
+                  "Session_StrengthOfField": "Strength Of Field",
+                  "Session_iRating": "iRating",
+                  "Track_Length": "Track Length",
+                  "_time_max": "Stop",
+                  "_time_min": "Start",
+                  "_value": "Car Number",
+                  "user": "User"
+                }
               }
-            ]
+            }
           ],
-          "tags": []
-        }
-      ],
-      "title": "Position",
-      "transparent": true,
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "influxdb",
-        "uid": "${DS_RACING}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "continuous-RdYlGr"
+          "transparent": true,
+          "type": "table"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 12
           },
-          "decimals": 0,
-          "mappings": [],
-          "min": 1,
-          "noValue": "0",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
+          "id": 11,
+          "panels": [],
+          "title": "Tyres Position Penalties",
+          "type": "row"
         },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 2,
-        "x": 12,
-        "y": 13
-      },
-      "id": 24,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "center",
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "text": {
-          "titleSize": 1
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "10.0.2",
-      "targets": [
         {
           "datasource": {
             "type": "influxdb",
             "uid": "${DS_RACING}"
           },
-          "groupBy": [
-            {
-              "params": [
-                "1s"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
-          ],
-          "measurement": "laps_cc",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Session_NumCars_Overall\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: ${SessionLen}s, fn: last, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Opponents\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "telemetry_Session_NumCars_Overall"
-                ],
-                "type": "field"
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "yellow",
+                "mode": "thresholds"
               },
-              {
-                "params": [],
-                "type": "last"
-              }
-            ]
-          ],
-          "tags": []
-        }
-      ],
-      "title": "Opponents ",
-      "transparent": true,
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "influxdb",
-        "uid": "${DS_RACING}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "orange",
-            "mode": "thresholds"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 12,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "area"
-            }
-          },
-          "decimals": 2,
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "red",
-                "value": null
-              },
-              {
-                "color": "green",
-                "value": 26
-              },
-              {
-                "color": "semi-dark-red",
-                "value": 27
-              }
-            ]
-          },
-          "unit": "pressurepsi"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Tyre"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "text",
-                  "mode": "fixed"
-                }
-              },
-              {
-                "id": "custom.axisPlacement",
-                "value": "hidden"
-              },
-              {
-                "id": "custom.hideFrom",
-                "value": {
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 40,
+                "gradientMode": "hue",
+                "hideFrom": {
                   "legend": false,
                   "tooltip": false,
                   "viz": false
-                }
-              },
-              {
-                "id": "min",
-                "value": 0
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Wear"
-            },
-            "properties": [
-              {
-                "id": "custom.axisPlacement",
-                "value": "right"
-              },
-              {
-                "id": "unit",
-                "value": "percent"
-              },
-              {
-                "id": "max"
-              },
-              {
-                "id": "custom.thresholdsStyle",
-                "value": {
-                  "mode": "dashed"
-                }
-              },
-              {
-                "id": "min"
-              },
-              {
-                "id": "custom.scaleDistribution",
-                "value": {
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "scaleDistribution": {
                   "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "area"
                 }
               },
-              {
-                "id": "color",
-                "value": {
-                  "mode": "thresholds"
-                }
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "dark-blue",
+                    "value": null
+                  },
+                  {
+                    "color": "dark-yellow",
+                    "value": 70
+                  },
+                  {
+                    "color": "dark-green",
+                    "value": 80
+                  },
+                  {
+                    "color": "dark-orange",
+                    "value": 90
+                  },
+                  {
+                    "color": "dark-red",
+                    "value": 100
+                  }
+                ]
               },
+              "unit": "celsius"
+            },
+            "overrides": [
               {
-                "id": "thresholds",
-                "value": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": null
-                    },
-                    {
-                      "color": "light-yellow",
-                      "value": 50
-                    },
-                    {
-                      "color": "semi-dark-orange",
-                      "value": 70
-                    },
-                    {
-                      "color": "semi-dark-red",
-                      "value": 80
-                    },
-                    {
-                      "color": "dark-red",
-                      "value": 90
+                "matcher": {
+                  "id": "byFrameRefID",
+                  "options": "BrakeTemp"
+                },
+                "properties": [
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "right"
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "light-blue",
+                          "value": null
+                        },
+                        {
+                          "color": "light-green",
+                          "value": 350
+                        },
+                        {
+                          "color": "light-red",
+                          "value": 650
+                        }
+                      ]
                     }
-                  ]
-                }
+                  },
+                  {
+                    "id": "custom.scaleDistribution",
+                    "value": {
+                      "type": "linear"
+                    }
+                  },
+                  {
+                    "id": "custom.thresholdsStyle",
+                    "value": {
+                      "mode": "dashed"
+                    }
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 0
+                  }
+                ]
               }
             ]
           },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "x10"
+          "gridPos": {
+            "h": 5,
+            "w": 5,
+            "x": 0,
+            "y": 13
+          },
+          "id": 41,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
             },
-            "properties": [
-              {
-                "id": "custom.axisPlacement",
-                "value": "hidden"
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "alias": "Brake",
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
               },
-              {
-                "id": "custom.hideFrom",
-                "value": {
-                  "legend": true,
-                  "tooltip": true,
-                  "viz": true
+              "groupBy": [
+                {
+                  "params": [
+                    "1s"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "0"
+                  ],
+                  "type": "fill"
                 }
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 5,
-        "x": 14,
-        "y": 13
-      },
-      "id": 8,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
+              ],
+              "hide": false,
+              "measurement": "laps_cc",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Front_Left_BrakeTemp\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Brake\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+              "refId": "BrakeTemp",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "telemetry_TyreData_Front_Left_BrakeTemp"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "max"
+                  }
+                ]
+              ],
+              "tags": []
+            },
+            {
+              "alias": "Core",
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "groupBy": [
+                {
+                  "params": [
+                    "1s"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "0"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "laps_cc",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Front_Left_CenterTemp\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Tyre Core\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()\r\n ",
+              "refId": "TyreCore",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "telemetry_TyreData_Front_Left_CenterTemp"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "max"
+                  }
+                ]
+              ],
+              "tags": []
+            }
+          ],
+          "title": "Front Left Temp",
+          "transformations": [],
+          "type": "timeseries"
         },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
         {
-          "alias": "Tyre",
           "datasource": {
             "type": "influxdb",
             "uid": "${DS_RACING}"
           },
-          "groupBy": [
-            {
-              "params": [
-                "1s"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "none"
-              ],
-              "type": "fill"
-            }
-          ],
-          "hide": false,
-          "measurement": "laps_cc",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Front_Left_Pressure\" and r._value >= 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Tyre\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-          "refId": "TyrePressure",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "telemetry_FrontLeftPressure"
-                ],
-                "type": "field"
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "yellow",
+                "mode": "thresholds"
               },
-              {
-                "params": [],
-                "type": "max"
-              }
-            ]
-          ],
-          "tags": []
-        },
-        {
-          "alias": "Wear",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "1s"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "none"
-              ],
-              "type": "fill"
-            }
-          ],
-          "hide": false,
-          "measurement": "laps_cc",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Front_Left_PercentWear\" and r._value >= 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n      \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Wear\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-          "refId": "TyreWear",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "telemetry_FrontLeftPercentWear"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "max"
-              }
-            ]
-          ],
-          "tags": []
-        }
-      ],
-      "title": "Front Left (PSI-Wear)",
-      "transformations": [
-        {
-          "id": "calculateField",
-          "options": {
-            "alias": "x10",
-            "binary": {
-              "left": "Tyre",
-              "operator": "*",
-              "reducer": "sum",
-              "right": "10"
-            },
-            "mode": "binary",
-            "reduce": {
-              "reducer": "sum"
-            }
-          }
-        },
-        {
-          "id": "calculateField",
-          "options": {
-            "alias": "PSI",
-            "binary": {
-              "left": "x10",
-              "operator": "/",
-              "reducer": "sum",
-              "right": "70.3070"
-            },
-            "mode": "binary",
-            "reduce": {
-              "reducer": "sum"
-            },
-            "replaceFields": false
-          }
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Tyre": true,
-              "x10": true
-            },
-            "indexByName": {},
-            "renameByName": {}
-          }
-        }
-      ],
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "influxdb",
-        "uid": "${DS_RACING}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "orange",
-            "mode": "thresholds"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 12,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "area"
-            }
-          },
-          "decimals": 2,
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "red",
-                "value": null
-              },
-              {
-                "color": "green",
-                "value": 26
-              },
-              {
-                "color": "semi-dark-red",
-                "value": 27
-              }
-            ]
-          },
-          "unit": "pressurepsi"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Tyre"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "text",
-                  "mode": "fixed"
-                }
-              },
-              {
-                "id": "custom.axisPlacement",
-                "value": "hidden"
-              },
-              {
-                "id": "custom.hideFrom",
-                "value": {
-                  "legend": true,
-                  "tooltip": true,
-                  "viz": true
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Wear"
-            },
-            "properties": [
-              {
-                "id": "custom.axisPlacement",
-                "value": "right"
-              },
-              {
-                "id": "unit",
-                "value": "percent"
-              },
-              {
-                "id": "thresholds",
-                "value": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": null
-                    },
-                    {
-                      "color": "#EAB839",
-                      "value": 60
-                    },
-                    {
-                      "color": "semi-dark-orange",
-                      "value": 70
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    },
-                    {
-                      "color": "dark-red",
-                      "value": 90
-                    }
-                  ]
-                }
-              },
-              {
-                "id": "max"
-              },
-              {
-                "id": "custom.thresholdsStyle",
-                "value": {
-                  "mode": "dashed"
-                }
-              },
-              {
-                "id": "min",
-                "value": 0
-              },
-              {
-                "id": "custom.scaleDistribution",
-                "value": {
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 40,
+                "gradientMode": "hue",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "scaleDistribution": {
                   "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "area"
                 }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "x10"
-            },
-            "properties": [
-              {
-                "id": "custom.axisPlacement",
-                "value": "hidden"
               },
-              {
-                "id": "custom.hideFrom",
-                "value": {
-                  "legend": true,
-                  "tooltip": true,
-                  "viz": true
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 5,
-        "x": 19,
-        "y": 13
-      },
-      "id": 42,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "alias": "Tyre",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "1s"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "none"
-              ],
-              "type": "fill"
-            }
-          ],
-          "hide": false,
-          "measurement": "laps_cc",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Front_Right_Pressure\"  and r._value >= 0)\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Tyre\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-          "refId": "TyrePressure",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "telemetry_FrontLeftPressure"
-                ],
-                "type": "field"
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "dark-blue",
+                    "value": null
+                  },
+                  {
+                    "color": "dark-yellow",
+                    "value": 70
+                  },
+                  {
+                    "color": "dark-green",
+                    "value": 80
+                  },
+                  {
+                    "color": "dark-orange",
+                    "value": 90
+                  },
+                  {
+                    "color": "dark-red",
+                    "value": 100
+                  }
+                ]
               },
-              {
-                "params": [],
-                "type": "max"
-              }
-            ]
-          ],
-          "tags": []
-        },
-        {
-          "alias": "Wear",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "1s"
-              ],
-              "type": "time"
+              "unit": "celsius"
             },
-            {
-              "params": [
-                "none"
-              ],
-              "type": "fill"
-            }
-          ],
-          "hide": false,
-          "measurement": "laps_cc",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Front_Right_PercentWear\" and r._value >= 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n      \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Wear\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-          "refId": "TyreWear",
-          "resultFormat": "time_series",
-          "select": [
-            [
+            "overrides": [
               {
-                "params": [
-                  "telemetry_FrontLeftPercentWear"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "max"
-              }
-            ]
-          ],
-          "tags": []
-        }
-      ],
-      "title": "Front Right (PSI-Wear)",
-      "transformations": [
-        {
-          "id": "calculateField",
-          "options": {
-            "alias": "x10",
-            "binary": {
-              "left": "Tyre",
-              "operator": "*",
-              "reducer": "sum",
-              "right": "10"
-            },
-            "mode": "binary",
-            "reduce": {
-              "reducer": "sum"
-            }
-          }
-        },
-        {
-          "id": "calculateField",
-          "options": {
-            "alias": "PSI",
-            "binary": {
-              "left": "x10",
-              "operator": "/",
-              "reducer": "sum",
-              "right": "70.3070"
-            },
-            "mode": "binary",
-            "reduce": {
-              "reducer": "sum"
-            },
-            "replaceFields": false
-          }
-        }
-      ],
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "influxdb",
-        "uid": "${DS_RACING}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "continuous-RdYlGr"
-          },
-          "decimals": 0,
-          "mappings": [],
-          "min": -1,
-          "noValue": "0",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 2,
-        "x": 10,
-        "y": 17
-      },
-      "id": 23,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "auto"
-      },
-      "pluginVersion": "10.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "1s"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
-          ],
-          "measurement": "laps_cc",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Penalties_CutTrackWarnings\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: ${SessionLen}s, fn: max, createEmpty: false)\r\n\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Cuts\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "telemetry_CutTrackWarnings"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "last"
-              }
-            ]
-          ],
-          "tags": []
-        }
-      ],
-      "title": "Cuts",
-      "transparent": true,
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "influxdb",
-        "uid": "${DS_RACING}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "continuous-RdYlGr"
-          },
-          "decimals": 0,
-          "mappings": [],
-          "min": -1,
-          "noValue": "0",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 2,
-        "x": 12,
-        "y": 17
-      },
-      "id": 45,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "auto"
-      },
-      "pluginVersion": "10.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "1s"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
-          ],
-          "measurement": "laps_cc",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Penalties_Incidents\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: ${SessionLen}s, fn: max, createEmpty: false)\r\n\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Incidents\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "telemetry_CutTrackWarnings"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "last"
-              }
-            ]
-          ],
-          "tags": []
-        }
-      ],
-      "title": "Incidents",
-      "transparent": true,
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "influxdb",
-        "uid": "${DS_RACING}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "yellow",
-            "mode": "thresholds"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 40,
-            "gradientMode": "hue",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "area"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "dark-blue",
-                "value": null
-              },
-              {
-                "color": "dark-yellow",
-                "value": 70
-              },
-              {
-                "color": "dark-green",
-                "value": 80
-              },
-              {
-                "color": "dark-orange",
-                "value": 90
-              },
-              {
-                "color": "dark-red",
-                "value": 100
-              }
-            ]
-          },
-          "unit": "celsius"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byFrameRefID",
-              "options": "BrakeTemp"
-            },
-            "properties": [
-              {
-                "id": "custom.axisPlacement",
-                "value": "right"
-              },
-              {
-                "id": "thresholds",
-                "value": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "light-blue",
-                      "value": null
-                    },
-                    {
-                      "color": "light-green",
-                      "value": 350
-                    },
-                    {
-                      "color": "light-red",
-                      "value": 650
+                "matcher": {
+                  "id": "byFrameRefID",
+                  "options": "BrakeTemp"
+                },
+                "properties": [
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "right"
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "light-blue",
+                          "value": null
+                        },
+                        {
+                          "color": "light-green",
+                          "value": 350
+                        },
+                        {
+                          "color": "light-red",
+                          "value": 650
+                        }
+                      ]
                     }
-                  ]
-                }
-              },
-              {
-                "id": "custom.scaleDistribution",
-                "value": {
-                  "type": "linear"
-                }
-              },
-              {
-                "id": "custom.thresholdsStyle",
-                "value": {
-                  "mode": "dashed"
-                }
-              },
-              {
-                "id": "custom.fillOpacity",
-                "value": 0
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 5,
-        "x": 0,
-        "y": 18
-      },
-      "id": 39,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "alias": "Core",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "1s"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "0"
-              ],
-              "type": "fill"
-            }
-          ],
-          "measurement": "laps_cc",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Rear_Left_CenterTemp\" and r._value >= 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Tyre Core\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()\r\n ",
-          "refId": "TyreCore",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "telemetry_TyreData_Front_Left_CenterTemp"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "max"
-              }
-            ]
-          ],
-          "tags": []
-        },
-        {
-          "alias": "Brake",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "1s"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "0"
-              ],
-              "type": "fill"
-            }
-          ],
-          "hide": false,
-          "measurement": "laps_cc",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Rear_Left_BrakeTemp\" and r._value >=0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Brake\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-          "refId": "BrakeTemp",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "telemetry_TyreData_Front_Left_BrakeTemp"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "max"
-              }
-            ]
-          ],
-          "tags": []
-        }
-      ],
-      "title": "Rear Left Temp",
-      "transformations": [],
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "influxdb",
-        "uid": "${DS_RACING}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "yellow",
-            "mode": "thresholds"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 40,
-            "gradientMode": "hue",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "area"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "dark-blue",
-                "value": null
-              },
-              {
-                "color": "dark-yellow",
-                "value": 70
-              },
-              {
-                "color": "dark-green",
-                "value": 80
-              },
-              {
-                "color": "dark-orange",
-                "value": 90
-              },
-              {
-                "color": "dark-red",
-                "value": 100
-              }
-            ]
-          },
-          "unit": "celsius"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byFrameRefID",
-              "options": "BrakeTemp"
-            },
-            "properties": [
-              {
-                "id": "custom.axisPlacement",
-                "value": "right"
-              },
-              {
-                "id": "thresholds",
-                "value": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "light-blue",
-                      "value": null
-                    },
-                    {
-                      "color": "light-green",
-                      "value": 350
-                    },
-                    {
-                      "color": "light-red",
-                      "value": 650
+                  },
+                  {
+                    "id": "custom.scaleDistribution",
+                    "value": {
+                      "type": "linear"
                     }
-                  ]
-                }
-              },
-              {
-                "id": "custom.scaleDistribution",
-                "value": {
-                  "type": "linear"
-                }
-              },
-              {
-                "id": "custom.thresholdsStyle",
-                "value": {
-                  "mode": "dashed"
-                }
-              },
-              {
-                "id": "custom.fillOpacity",
-                "value": 0
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 5,
-        "x": 5,
-        "y": 18
-      },
-      "id": 40,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "alias": "Core",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "1s"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "0"
-              ],
-              "type": "fill"
-            }
-          ],
-          "measurement": "laps_cc",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Rear_Right_CenterTemp\" and r._value >= 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Tyre Core\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()\r\n ",
-          "refId": "TyreCore",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "telemetry_TyreData_Front_Left_CenterTemp"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "max"
-              }
-            ]
-          ],
-          "tags": []
-        },
-        {
-          "alias": "Brake",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "1s"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "0"
-              ],
-              "type": "fill"
-            }
-          ],
-          "hide": false,
-          "measurement": "laps_cc",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Rear_Right_BrakeTemp\" and r._value >=0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Brake\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-          "refId": "BrakeTemp",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "telemetry_TyreData_Front_Left_BrakeTemp"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "max"
-              }
-            ]
-          ],
-          "tags": []
-        }
-      ],
-      "title": "Rear Right Temp",
-      "transformations": [],
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "influxdb",
-        "uid": "${DS_RACING}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "orange",
-            "mode": "thresholds"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 12,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "area"
-            }
-          },
-          "decimals": 2,
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "red",
-                "value": null
-              },
-              {
-                "color": "green",
-                "value": 26
-              },
-              {
-                "color": "semi-dark-red",
-                "value": 27
-              }
-            ]
-          },
-          "unit": "pressurepsi"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Tyre"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "text",
-                  "mode": "fixed"
-                }
-              },
-              {
-                "id": "custom.axisPlacement",
-                "value": "hidden"
-              },
-              {
-                "id": "custom.hideFrom",
-                "value": {
-                  "legend": true,
-                  "tooltip": true,
-                  "viz": true
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Wear"
-            },
-            "properties": [
-              {
-                "id": "custom.axisPlacement",
-                "value": "right"
-              },
-              {
-                "id": "unit",
-                "value": "percent"
-              },
-              {
-                "id": "thresholds",
-                "value": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": null
-                    },
-                    {
-                      "color": "yellow",
-                      "value": 60
-                    },
-                    {
-                      "color": "semi-dark-orange",
-                      "value": 70
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    },
-                    {
-                      "color": "dark-red",
-                      "value": 90
+                  },
+                  {
+                    "id": "custom.thresholdsStyle",
+                    "value": {
+                      "mode": "dashed"
                     }
-                  ]
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 0
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 5,
+            "x": 5,
+            "y": 13
+          },
+          "id": 36,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "alias": "Core",
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "groupBy": [
+                {
+                  "params": [
+                    "1s"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "0"
+                  ],
+                  "type": "fill"
                 }
+              ],
+              "measurement": "laps_cc",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Front_Right_CenterTemp\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Tyre Core\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()\r\n ",
+              "refId": "TyreCore",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "telemetry_TyreData_Front_Left_CenterTemp"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "max"
+                  }
+                ]
+              ],
+              "tags": []
+            },
+            {
+              "alias": "Brake",
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
               },
-              {
-                "id": "max"
-              },
-              {
-                "id": "custom.thresholdsStyle",
-                "value": {
-                  "mode": "dashed"
+              "groupBy": [
+                {
+                  "params": [
+                    "1s"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "0"
+                  ],
+                  "type": "fill"
                 }
+              ],
+              "hide": false,
+              "measurement": "laps_cc",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Front_Right_BrakeTemp\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Brake\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+              "refId": "BrakeTemp",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "telemetry_TyreData_Front_Left_BrakeTemp"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "max"
+                  }
+                ]
+              ],
+              "tags": []
+            }
+          ],
+          "title": "Front Right Temp",
+          "transformations": [],
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-RdYlGr"
               },
-              {
-                "id": "min",
-                "value": 0
+              "decimals": 0,
+              "mappings": [],
+              "min": 1,
+              "noValue": "0",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 2,
+            "x": 10,
+            "y": 13
+          },
+          "id": 22,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "center",
+            "orientation": "vertical",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {
+              "titleSize": 1
+            },
+            "textMode": "value"
+          },
+          "pluginVersion": "10.0.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
               },
-              {
-                "id": "custom.scaleDistribution",
-                "value": {
+              "groupBy": [
+                {
+                  "params": [
+                    "1s"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "laps_cc",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Session_Position_Overall\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: last, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Position\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "telemetry_Session_Position_Overall"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  }
+                ]
+              ],
+              "tags": []
+            }
+          ],
+          "title": "Position",
+          "transparent": true,
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-RdYlGr"
+              },
+              "decimals": 0,
+              "mappings": [],
+              "min": 1,
+              "noValue": "0",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 2,
+            "x": 12,
+            "y": 13
+          },
+          "id": 24,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "center",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {
+              "titleSize": 1
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "10.0.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "groupBy": [
+                {
+                  "params": [
+                    "1s"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "laps_cc",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Session_NumCars_Overall\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: ${SessionLen}s, fn: last, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Opponents\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "telemetry_Session_NumCars_Overall"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  }
+                ]
+              ],
+              "tags": []
+            }
+          ],
+          "title": "Opponents ",
+          "transparent": true,
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "orange",
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 12,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "scaleDistribution": {
                   "type": "linear"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "x10"
-            },
-            "properties": [
-              {
-                "id": "custom.axisPlacement",
-                "value": "hidden"
-              },
-              {
-                "id": "custom.hideFrom",
-                "value": {
-                  "legend": true,
-                  "tooltip": true,
-                  "viz": true
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 5,
-        "x": 14,
-        "y": 18
-      },
-      "id": 43,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "alias": "Tyre",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "1s"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "none"
-              ],
-              "type": "fill"
-            }
-          ],
-          "hide": false,
-          "measurement": "laps_cc",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Rear_Left_Pressure\" and r._value >= 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Tyre\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-          "refId": "TyrePressure",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "telemetry_FrontLeftPressure"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "max"
-              }
-            ]
-          ],
-          "tags": []
-        },
-        {
-          "alias": "Wear",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "1s"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "none"
-              ],
-              "type": "fill"
-            }
-          ],
-          "hide": false,
-          "measurement": "laps_cc",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Rear_Left_PercentWear\" and r._value >= 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n      \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Wear\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-          "refId": "TyreWear",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "telemetry_FrontLeftPercentWear"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "max"
-              }
-            ]
-          ],
-          "tags": []
-        }
-      ],
-      "title": "Rear Left (PSI-Wear)",
-      "transformations": [
-        {
-          "id": "calculateField",
-          "options": {
-            "alias": "x10",
-            "binary": {
-              "left": "Tyre",
-              "operator": "*",
-              "reducer": "sum",
-              "right": "10"
-            },
-            "mode": "binary",
-            "reduce": {
-              "reducer": "sum"
-            }
-          }
-        },
-        {
-          "id": "calculateField",
-          "options": {
-            "alias": "PSI",
-            "binary": {
-              "left": "x10",
-              "operator": "/",
-              "reducer": "sum",
-              "right": "70.3070"
-            },
-            "mode": "binary",
-            "reduce": {
-              "reducer": "sum"
-            },
-            "replaceFields": false
-          }
-        }
-      ],
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "influxdb",
-        "uid": "${DS_RACING}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "orange",
-            "mode": "thresholds"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 12,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "area"
-            }
-          },
-          "decimals": 2,
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "red",
-                "value": null
-              },
-              {
-                "color": "green",
-                "value": 26
-              },
-              {
-                "color": "semi-dark-red",
-                "value": 27
-              }
-            ]
-          },
-          "unit": "pressurepsi"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Tyre"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "text",
-                  "mode": "fixed"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "area"
                 }
               },
-              {
-                "id": "custom.axisPlacement",
-                "value": "hidden"
+              "decimals": 2,
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 26
+                  },
+                  {
+                    "color": "semi-dark-red",
+                    "value": 27
+                  }
+                ]
               },
-              {
-                "id": "custom.hideFrom",
-                "value": {
-                  "legend": true,
-                  "tooltip": true,
-                  "viz": true
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Wear"
+              "unit": "pressurepsi"
             },
-            "properties": [
+            "overrides": [
               {
-                "id": "custom.axisPlacement",
-                "value": "right"
-              },
-              {
-                "id": "unit",
-                "value": "percent"
-              },
-              {
-                "id": "thresholds",
-                "value": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": null
-                    },
-                    {
-                      "color": "yellow",
-                      "value": 60
-                    },
-                    {
-                      "color": "semi-dark-orange",
-                      "value": 70
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    },
-                    {
-                      "color": "dark-red",
-                      "value": 90
+                "matcher": {
+                  "id": "byName",
+                  "options": "Tyre"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "text",
+                      "mode": "fixed"
                     }
-                  ]
-                }
+                  },
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "hidden"
+                  },
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    }
+                  },
+                  {
+                    "id": "min",
+                    "value": 0
+                  }
+                ]
               },
               {
-                "id": "max"
+                "matcher": {
+                  "id": "byName",
+                  "options": "Wear"
+                },
+                "properties": [
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "right"
+                  },
+                  {
+                    "id": "unit",
+                    "value": "percent"
+                  },
+                  {
+                    "id": "max"
+                  },
+                  {
+                    "id": "custom.thresholdsStyle",
+                    "value": {
+                      "mode": "dashed"
+                    }
+                  },
+                  {
+                    "id": "min"
+                  },
+                  {
+                    "id": "custom.scaleDistribution",
+                    "value": {
+                      "type": "linear"
+                    }
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "mode": "thresholds"
+                    }
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green",
+                          "value": null
+                        },
+                        {
+                          "color": "light-yellow",
+                          "value": 50
+                        },
+                        {
+                          "color": "semi-dark-orange",
+                          "value": 70
+                        },
+                        {
+                          "color": "semi-dark-red",
+                          "value": 80
+                        },
+                        {
+                          "color": "dark-red",
+                          "value": 90
+                        }
+                      ]
+                    }
+                  }
+                ]
               },
               {
-                "id": "custom.thresholdsStyle",
-                "value": {
-                  "mode": "dashed"
-                }
-              },
-              {
-                "id": "min",
-                "value": 0
-              },
-              {
-                "id": "custom.scaleDistribution",
-                "value": {
-                  "type": "linear"
-                }
+                "matcher": {
+                  "id": "byName",
+                  "options": "x10"
+                },
+                "properties": [
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "hidden"
+                  },
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": true,
+                      "tooltip": true,
+                      "viz": true
+                    }
+                  }
+                ]
               }
             ]
           },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "x10"
-            },
-            "properties": [
-              {
-                "id": "custom.axisPlacement",
-                "value": "hidden"
-              },
-              {
-                "id": "custom.hideFrom",
-                "value": {
-                  "legend": true,
-                  "tooltip": true,
-                  "viz": true
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 5,
-        "x": 19,
-        "y": 18
-      },
-      "id": 44,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "alias": "Tyre",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
+          "gridPos": {
+            "h": 5,
+            "w": 5,
+            "x": 14,
+            "y": 13
           },
-          "groupBy": [
-            {
-              "params": [
-                "1s"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "none"
-              ],
-              "type": "fill"
-            }
-          ],
-          "hide": false,
-          "measurement": "laps_cc",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Rear_Right_Pressure\" and r._value >= 0)\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Tyre\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-          "refId": "TyrePressure",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "telemetry_FrontLeftPressure"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "max"
-              }
-            ]
-          ],
-          "tags": []
-        },
-        {
-          "alias": "Wear",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "1s"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "none"
-              ],
-              "type": "fill"
-            }
-          ],
-          "hide": false,
-          "measurement": "laps_cc",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Rear_Right_PercentWear\"  and r._value >= 0)\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n      \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Wear\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-          "refId": "TyreWear",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "telemetry_FrontLeftPercentWear"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "max"
-              }
-            ]
-          ],
-          "tags": []
-        }
-      ],
-      "title": "Rear Right (PSI-Wear)",
-      "transformations": [
-        {
-          "id": "calculateField",
+          "id": 8,
           "options": {
-            "alias": "x10",
-            "binary": {
-              "left": "Tyre",
-              "operator": "*",
-              "reducer": "sum",
-              "right": "10"
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
             },
-            "mode": "binary",
-            "reduce": {
-              "reducer": "sum"
-            }
-          }
-        },
-        {
-          "id": "calculateField",
-          "options": {
-            "alias": "PSI",
-            "binary": {
-              "left": "x10",
-              "operator": "/",
-              "reducer": "sum",
-              "right": "70.3070"
-            },
-            "mode": "binary",
-            "reduce": {
-              "reducer": "sum"
-            },
-            "replaceFields": false
-          }
-        }
-      ],
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "influxdb",
-        "uid": "${DS_RACING}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "continuous-RdYlGr"
-          },
-          "decimals": 0,
-          "mappings": [],
-          "min": -1,
-          "noValue": "0",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 2,
-        "x": 10,
-        "y": 20
-      },
-      "id": 46,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "auto"
-      },
-      "pluginVersion": "10.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "1s"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
-          ],
-          "measurement": "laps_cc",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Penalties_Total\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: ${SessionLen}s, fn: max, createEmpty: false)\r\n\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Penalties\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "telemetry_CutTrackWarnings"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "last"
-              }
-            ]
-          ],
-          "tags": []
-        }
-      ],
-      "title": "Penalties",
-      "transparent": true,
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "influxdb",
-        "uid": "${DS_RACING}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "decimals": 0,
-          "mappings": [],
-          "noValue": "0",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "red",
-                "value": null
-              },
-              {
-                "color": "orange",
-                "value": 0.1
-              },
-              {
-                "color": "yellow",
-                "value": 0.25
-              },
-              {
-                "color": "#88bf69",
-                "value": 0.5
-              },
-              {
-                "color": "dark-green",
-                "value": 0.6
-              }
-            ]
-          },
-          "unit": "percentunit"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 2,
-        "x": 12,
-        "y": 20
-      },
-      "id": 51,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "center",
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "/^Fuel%$/",
-          "values": false
-        },
-        "textMode": "value"
-      },
-      "pluginVersion": "10.0.2",
-      "targets": [
-        {
-          "alias": "Tyre",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "1s"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "none"
-              ],
-              "type": "fill"
-            }
-          ],
-          "hide": false,
-          "measurement": "laps_cc",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"FuelData_FuelCapacity\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"FuelCapacity\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-          "refId": "FuelCapacity",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "telemetry_FrontLeftPressure"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "max"
-              }
-            ]
-          ],
-          "tags": []
-        },
-        {
-          "alias": "Wear",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "1s"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "none"
-              ],
-              "type": "fill"
-            }
-          ],
-          "hide": false,
-          "measurement": "laps_cc",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"FuelData_FuelLeft\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n      \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"FuelLeft\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-          "refId": "FuelLeft",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "telemetry_FrontLeftPercentWear"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "max"
-              }
-            ]
-          ],
-          "tags": []
-        }
-      ],
-      "title": "Fuel %",
-      "transformations": [
-        {
-          "id": "calculateField",
-          "options": {
-            "alias": "Fuel%",
-            "binary": {
-              "left": "FuelLeft",
-              "operator": "/",
-              "reducer": "sum",
-              "right": "FuelCapacity"
-            },
-            "mode": "binary",
-            "reduce": {
-              "reducer": "sum"
-            },
-            "replaceFields": true
-          }
-        }
-      ],
-      "transparent": true,
-      "type": "stat"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 23
-      },
-      "id": 4,
-      "panels": [],
-      "title": "Time Speed Inputs",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "influxdb",
-        "uid": "${DS_RACING}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "purple",
-            "mode": "fixed"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "Lap time",
-            "axisPlacement": "left",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 51,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
             }
           },
-          "mappings": [
+          "targets": [
             {
+              "alias": "Tyre",
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "groupBy": [
+                {
+                  "params": [
+                    "1s"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "none"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "hide": false,
+              "measurement": "laps_cc",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Front_Left_Pressure\" and r._value >= 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Tyre\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+              "refId": "TyrePressure",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "telemetry_FrontLeftPressure"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "max"
+                  }
+                ]
+              ],
+              "tags": []
+            },
+            {
+              "alias": "Wear",
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "groupBy": [
+                {
+                  "params": [
+                    "1s"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "none"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "hide": false,
+              "measurement": "laps_cc",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Front_Left_PercentWear\" and r._value >= 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n      \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Wear\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+              "refId": "TyreWear",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "telemetry_FrontLeftPercentWear"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "max"
+                  }
+                ]
+              ],
+              "tags": []
+            }
+          ],
+          "title": "Front Left (PSI-Wear)",
+          "transformations": [
+            {
+              "id": "calculateField",
               "options": {
-                "1": {
-                  "color": "green",
-                  "index": 0
+                "alias": "x10",
+                "binary": {
+                  "left": "Tyre",
+                  "operator": "*",
+                  "reducer": "sum",
+                  "right": "10"
                 },
-                "2": {
-                  "color": "purple",
-                  "index": 1
-                },
-                "3": {
-                  "color": "yellow",
-                  "index": 2
-                },
-                "4": {
-                  "color": "#a5f700",
-                  "index": 3
-                },
-                "5": {
-                  "color": "semi-dark-blue",
-                  "index": 4
-                },
-                "6": {
-                  "color": "#ba05f7",
-                  "index": 5
-                },
-                "7": {
-                  "color": "#0affb9",
-                  "index": 6
-                }
-              },
-              "type": "value"
-            }
-          ],
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "clocks"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byFrameRefID",
-              "options": "Lap"
-            },
-            "properties": [
-              {
-                "id": "custom.axisPlacement",
-                "value": "right"
-              },
-              {
-                "id": "custom.axisLabel",
-                "value": "Laps Num"
-              },
-              {
-                "id": "unit",
-                "value": "none"
-              },
-              {
-                "id": "custom.scaleDistribution",
-                "value": {
-                  "type": "linear"
-                }
-              },
-              {
-                "id": "decimals",
-                "value": 0
-              },
-              {
-                "id": "custom.lineWidth",
-                "value": 2
-              },
-              {
-                "id": "custom.fillOpacity",
-                "value": 0
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "dark-yellow",
-                  "mode": "fixed"
+                "mode": "binary",
+                "reduce": {
+                  "reducer": "sum"
                 }
               }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 10,
-        "x": 0,
-        "y": 24
-      },
-      "id": 18,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": false
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "alias": "Last Lap",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "1s"
-              ],
-              "type": "time"
             },
             {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
-          ],
-          "measurement": "laps_cc",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"LapTimePrevious\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Lap Valid Time\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-          "refId": "LapTime",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "telemetry_LapTimePrevious"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "max"
-              }
-            ]
-          ],
-          "tags": []
-        },
-        {
-          "alias": "Lap",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "$__interval"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
-          ],
-          "hide": false,
-          "measurement": "laps_cc",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"CurrentLap\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Lap #\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-          "refId": "Lap",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "telemetry_CurrentLap"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "mean"
-              }
-            ]
-          ],
-          "tags": []
-        }
-      ],
-      "title": "Last Lap",
-      "transparent": true,
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "influxdb",
-        "uid": "${DS_RACING}"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "#be60f2",
-            "mode": "fixed"
-          },
-          "decimals": 0,
-          "mappings": [],
-          "noValue": "0",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "light-red",
-                "value": null
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 4,
-        "x": 10,
-        "y": 24
-      },
-      "id": 6,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "value_and_name"
-      },
-      "pluginVersion": "10.0.2",
-      "targets": [
-        {
-          "alias": "maxspeedms",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "1m"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "0"
-              ],
-              "type": "fill"
-            }
-          ],
-          "hide": false,
-          "measurement": "laps_cc",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"SpeedMs\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1d, fn: max, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"maxspeedms\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "telemetry_SpeedMs"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "max"
-              }
-            ]
-          ],
-          "tags": []
-        }
-      ],
-      "title": "Top Speed",
-      "transformations": [
-        {
-          "id": "calculateField",
-          "options": {
-            "alias": "${Speed:text}",
-            "binary": {
-              "left": "_value",
-              "operator": "*",
-              "reducer": "sum",
-              "right": "${Speed}"
-            },
-            "mode": "binary",
-            "reduce": {
-              "include": [
-                "laps_cc.last"
-              ],
-              "reducer": "sum"
-            },
-            "replaceFields": true
-          }
-        }
-      ],
-      "transparent": true,
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "influxdb",
-        "uid": "${DS_RACING}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "log": 2,
-              "type": "symlog"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byFrameRefID",
-              "options": "B"
-            },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "Delta Behind"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byFrameRefID",
-              "options": "A"
-            },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "Delta Front"
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 10,
-        "x": 14,
-        "y": 24
-      },
-      "id": 20,
-      "options": {
-        "legend": {
-          "calcs": [
-            "mean"
-          ],
-          "displayMode": "list",
-          "placement": "right",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "alias": "Delta Front",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "1s"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
-          ],
-          "measurement": "laps_cc",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Session_Delta_Front\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Delta_Front\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "telemetry_DeltaFront"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "max"
-              }
-            ]
-          ],
-          "tags": []
-        },
-        {
-          "alias": "Delta Behind",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "1s"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "0"
-              ],
-              "type": "fill"
-            }
-          ],
-          "hide": false,
-          "measurement": "laps_cc",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Session_Delta_Behind\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Delta_Behind\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-          "refId": "B",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "telemetry_DeltaBehind"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "max"
-              }
-            ]
-          ],
-          "tags": []
-        }
-      ],
-      "title": "Deltas",
-      "transparent": true,
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "influxdb",
-        "uid": "${DS_RACING}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "left",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 20,
-            "gradientMode": "opacity",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "SpeedMs"
-            },
-            "properties": [
-              {
-                "id": "custom.hideFrom",
-                "value": {
-                  "legend": true,
-                  "tooltip": true,
-                  "viz": true
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Sector"
-            },
-            "properties": [
-              {
-                "id": "custom.axisPlacement",
-                "value": "right"
-              },
-              {
-                "id": "displayName",
-                "value": "Sector"
-              },
-              {
-                "id": "max",
-                "value": 3
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "dark-yellow",
-                  "mode": "fixed"
-                }
-              },
-              {
-                "id": "custom.fillOpacity",
-                "value": 0
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "PitLimitMs"
-            },
-            "properties": [
-              {
-                "id": "custom.hideFrom",
-                "value": {
-                  "legend": true,
-                  "tooltip": true,
-                  "viz": true
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Km/h"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "dark-blue",
-                  "mode": "shades"
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 24,
-        "x": 0,
-        "y": 29
-      },
-      "id": 16,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "9.4.7",
-      "targets": [
-        {
-          "alias": "maxspeedms",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "1s"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
-          ],
-          "hide": false,
-          "measurement": "laps_cc",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"SpeedMs\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"SpeedMs\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-          "refId": "SpeedMs",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "telemetry_SpeedMs"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "max"
-              }
-            ]
-          ],
-          "tags": []
-        },
-        {
-          "alias": "Section",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "1s"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
-          ],
-          "hide": false,
-          "measurement": "laps_cc",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"PitData_PitSpeedLimit\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"PitLimitMs\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-          "refId": "PitLimit",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "telemetry_Sector"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "max"
-              }
-            ]
-          ],
-          "tags": []
-        },
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "hide": false,
-          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Session_Sector\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Sector\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-          "refId": "Sector"
-        }
-      ],
-      "title": "Speed",
-      "transformations": [
-        {
-          "id": "calculateField",
-          "options": {
-            "alias": "${Speed:text}",
-            "binary": {
-              "left": "SpeedMs",
-              "operator": "*",
-              "reducer": "sum",
-              "right": "${Speed}"
-            },
-            "mode": "binary",
-            "reduce": {
-              "include": [
-                "laps_cc.last"
-              ],
-              "reducer": "sum"
-            },
-            "replaceFields": false
-          }
-        },
-        {
-          "id": "calculateField",
-          "options": {
-            "alias": "Pit Limit",
-            "binary": {
-              "left": "PitLimitMs",
-              "operator": "*",
-              "reducer": "sum",
-              "right": "${Speed}"
-            },
-            "mode": "binary",
-            "reduce": {
-              "reducer": "sum"
-            }
-          }
-        }
-      ],
-      "transparent": true,
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "influxdb",
-        "uid": "${DS_RACING}"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 2,
-            "gradientMode": "scheme",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "percentunit"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byFrameRefID",
-              "options": "SteeringAngle"
-            },
-            "properties": [
-              {
-                "id": "custom.axisPlacement",
-                "value": "right"
-              },
-              {
-                "id": "unit",
-                "value": "none"
-              },
-              {
-                "id": "custom.fillOpacity",
-                "value": 22
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "super-light-orange",
-                  "mode": "fixed",
-                  "seriesBy": "min"
-                }
-              },
-              {
-                "id": "displayName",
-                "value": "SteeringAngle"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byFrameRefID",
-              "options": "Brake"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "dark-red",
-                  "mode": "fixed"
-                }
-              },
-              {
-                "id": "displayName",
-                "value": "Brake"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byFrameRefID",
-              "options": "Throttle"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "dark-green",
-                  "mode": "fixed"
-                }
-              },
-              {
-                "id": "displayName",
-                "value": "Throttle"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byFrameRefID",
-              "options": "Clutch"
-            },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "Clutch"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "orange",
-                  "mode": "fixed"
-                }
-              },
-              {
-                "id": "custom.fillOpacity",
-                "value": 2
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byFrameRefID",
-              "options": "Handbrake"
-            },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "Handbrake"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "dark-blue",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 24,
-        "x": 0,
-        "y": 35
-      },
-      "id": 2,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "alias": "Brake",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "1s"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "0"
-              ],
-              "type": "fill"
-            }
-          ],
-          "hide": false,
-          "measurement": "laps_cc",
-          "orderByTime": "ASC",
-          "policy": "autogen",
-          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Brake\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: last, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n  |> set(key: \"_field\", value: \"Brake\")\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Brake\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-          "refId": "Brake",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "telemetry_Brake"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "last"
-              }
-            ]
-          ],
-          "tags": []
-        },
-        {
-          "alias": "Throttle",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "1s"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "0"
-              ],
-              "type": "fill"
-            }
-          ],
-          "hide": false,
-          "measurement": "laps_cc",
-          "orderByTime": "ASC",
-          "policy": "autogen",
-          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Throttle\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: last, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n  |> set(key: \"_field\", value: \"Throttle\")\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Throttle\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-          "refId": "Throttle",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "telemetry_Throttle"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "last"
-              }
-            ]
-          ],
-          "tags": []
-        },
-        {
-          "alias": "Steer",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "1s"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "linear"
-              ],
-              "type": "fill"
-            }
-          ],
-          "hide": false,
-          "measurement": "laps_cc",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"SteeringAngle\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: last, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n  |> set(key: \"_field\", value: \"SteeringAngle\")\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"SteeringAngle\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-          "refId": "SteeringAngle",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "telemetry_SteeringAngle"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "max"
-              }
-            ]
-          ],
-          "tags": []
-        },
-        {
-          "alias": "Throttle",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "1s"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "0"
-              ],
-              "type": "fill"
-            }
-          ],
-          "hide": false,
-          "measurement": "laps_cc",
-          "orderByTime": "ASC",
-          "policy": "autogen",
-          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Clutch\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: last, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n  |> set(key: \"_field\", value: \"Clutch\")\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Clutch\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-          "refId": "Clutch",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "telemetry_Throttle"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "last"
-              }
-            ]
-          ],
-          "tags": []
-        },
-        {
-          "alias": "Throttle",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "1s"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "0"
-              ],
-              "type": "fill"
-            }
-          ],
-          "hide": false,
-          "measurement": "laps_cc",
-          "orderByTime": "ASC",
-          "policy": "autogen",
-          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Handbrake\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: last, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n  |> set(key: \"_field\", value: \"Handbrake\")\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Handbrake\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-          "refId": "Handbrake",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "telemetry_Throttle"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "last"
-              }
-            ]
-          ],
-          "tags": []
-        }
-      ],
-      "title": "Inputs",
-      "transparent": true,
-      "type": "timeseries"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 44
-      },
-      "id": 52,
-      "panels": [],
-      "title": "Engine Data ",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "influxdb",
-        "uid": "${DS_RACING}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "series",
-            "axisLabel": "RPMs",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "decimals": 0,
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byFrameRefID",
-              "options": "Gear"
-            },
-            "properties": [
-              {
-                "id": "custom.axisPlacement",
-                "value": "right"
-              },
-              {
-                "id": "displayName",
-                "value": "Gear"
-              },
-              {
-                "id": "custom.axisLabel",
-                "value": "Gears"
-              },
-              {
-                "id": "custom.lineInterpolation",
-                "value": "stepBefore"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byFrameRefID",
-              "options": "RPM"
-            },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "RPM"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byFrameRefID",
-              "options": "MaxRPM"
-            },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "Max RPM"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "dark-red",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 24,
-        "x": 0,
-        "y": 45
-      },
-      "id": 35,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "1s"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "none"
-              ],
-              "type": "fill"
-            }
-          ],
-          "measurement": "laps_cc",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"EngineData_EngineRpm\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n  |> set(key: \"_field\", value: \"EngineData_EngineRpm\")\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"EngineData_EngineRpm\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-          "refId": "RPM",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "telemetry_Rpms"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "max"
-              }
-            ]
-          ],
-          "tags": []
-        },
-        {
-          "alias": "Gear",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "1s"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "none"
-              ],
-              "type": "fill"
-            }
-          ],
-          "hide": false,
-          "measurement": "laps_cc",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Gear\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: last, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n  |> set(key: \"_field\", value: \"Gear\")\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Gear\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-          "refId": "Gear",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "telemetry_Gear"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "max"
-              }
-            ]
-          ],
-          "tags": []
-        },
-        {
-          "alias": "Max",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "1s"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "none"
-              ],
-              "type": "fill"
-            }
-          ],
-          "hide": false,
-          "measurement": "laps_cc",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"EngineData_MaxEngineRpm\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n  |> set(key: \"_field\", value: \"EngineData_MaxEngineRpm\")\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"EngineData_MaxEngineRpm\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-          "refId": "MaxRPM",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "telemetry_EngineData_MaxEngineRpm"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "max"
-              }
-            ]
-          ],
-          "tags": []
-        }
-      ],
-      "title": "Engine RPMs",
-      "transformations": [],
-      "transparent": true,
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "influxdb",
-        "uid": "${DS_RACING}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds",
-            "seriesBy": "last"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "series",
-            "axisLabel": "%",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "area"
-            }
-          },
-          "decimals": 0,
-          "mappings": [],
-          "max": 1,
-          "noValue": "0",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "super-light-yellow"
-              },
-              {
-                "color": "light-blue",
-                "value": 0
-              },
-              {
-                "color": "dark-green",
-                "value": 0.55
-              },
-              {
-                "color": "dark-red",
-                "value": 0.9
-              }
-            ]
-          },
-          "unit": "percentunit"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 24,
-        "x": 0,
-        "y": 51
-      },
-      "id": 47,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "1s"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "none"
-              ],
-              "type": "fill"
-            }
-          ],
-          "measurement": "laps_cc",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"EngineData_EngineRpm\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n  |> set(key: \"_field\", value: \"EngineData_EngineRpm\")\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"EngineData_EngineRpm\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-          "refId": "RPM",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "telemetry_Rpms"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "max"
-              }
-            ]
-          ],
-          "tags": []
-        },
-        {
-          "alias": "Max",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "1s"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "none"
-              ],
-              "type": "fill"
-            }
-          ],
-          "hide": false,
-          "measurement": "laps_cc",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"EngineData_MaxEngineRpm\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n  |> set(key: \"_field\", value: \"EngineData_MaxEngineRpm\")\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"EngineData_MaxEngineRpm\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-          "refId": "MaxRPM",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "telemetry_EngineData_MaxEngineRpm"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "max"
-              }
-            ]
-          ],
-          "tags": []
-        }
-      ],
-      "title": "Engine RPM %",
-      "transformations": [
-        {
-          "id": "calculateField",
-          "options": {
-            "alias": "%RPM",
-            "binary": {
-              "left": "_value 1",
-              "operator": "/",
-              "reducer": "sum",
-              "right": "_value 2"
-            },
-            "mode": "binary",
-            "reduce": {
-              "reducer": "sum"
-            },
-            "replaceFields": true
-          }
-        }
-      ],
-      "transparent": true,
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "influxdb",
-        "uid": "${DS_RACING}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "yellow",
-            "mode": "thresholds"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 12,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "area"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "dark-blue"
-              },
-              {
-                "color": "dark-yellow",
-                "value": 70
-              },
-              {
-                "color": "dark-green",
-                "value": 80
-              },
-              {
-                "color": "dark-orange",
-                "value": 100
-              },
-              {
-                "color": "dark-red",
-                "value": 143
-              }
-            ]
-          },
-          "unit": "celsius"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byFrameRefID",
-              "options": "EngineOilTemp"
-            },
-            "properties": [
-              {
-                "id": "custom.axisPlacement",
-                "value": "right"
-              },
-              {
-                "id": "thresholds",
-                "value": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "blue"
-                    },
-                    {
-                      "color": "light-green",
-                      "value": 82
-                    },
-                    {
-                      "color": "orange",
-                      "value": 104
-                    },
-                    {
-                      "color": "red",
-                      "value": 140
-                    }
-                  ]
-                }
-              },
-              {
-                "id": "custom.scaleDistribution",
-                "value": {
-                  "type": "linear"
-                }
-              },
-              {
-                "id": "custom.thresholdsStyle",
-                "value": {
-                  "mode": "dashed"
-                }
-              },
-              {
-                "id": "displayName",
-                "value": "Oil"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byFrameRefID",
-              "options": "WaterTemp"
-            },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "Water"
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 9,
-        "x": 0,
-        "y": 57
-      },
-      "id": 48,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "alias": "Core",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "1s"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "0"
-              ],
-              "type": "fill"
-            }
-          ],
-          "measurement": "laps_cc",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"EngineData_EngineWaterTemp\" and r._value >=0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"EngineData_EngineWaterTemp\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()\r\n ",
-          "refId": "WaterTemp",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "telemetry_TyreData_Front_Left_CenterTemp"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "max"
-              }
-            ]
-          ],
-          "tags": []
-        },
-        {
-          "alias": "Brake",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "1s"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "0"
-              ],
-              "type": "fill"
-            }
-          ],
-          "hide": false,
-          "measurement": "laps_cc",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"EngineData_EngineOilTemp\" and r._value >= 0)\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"EngineData_EngineOilTemp\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-          "refId": "EngineOilTemp",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "telemetry_TyreData_Front_Left_BrakeTemp"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "max"
-              }
-            ]
-          ],
-          "tags": []
-        }
-      ],
-      "title": "Engine Temps",
-      "transformations": [],
-      "transparent": true,
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "influxdb",
-        "uid": "${DS_RACING}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "orange",
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 12,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "min": 0,
-          "noValue": "0",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "red"
-              },
-              {
-                "color": "green",
-                "value": 26
-              },
-              {
-                "color": "semi-dark-red",
-                "value": 27
-              }
-            ]
-          },
-          "unit": "litre"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 8,
-        "x": 9,
-        "y": 57
-      },
-      "id": 50,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "alias": "Tyre",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "1s"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "none"
-              ],
-              "type": "fill"
-            }
-          ],
-          "hide": false,
-          "measurement": "laps_cc",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"FuelData_FuelCapacity\" and r._value >= 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"FuelCapacity\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-          "refId": "FuelCapacity",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "telemetry_FrontLeftPressure"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "max"
-              }
-            ]
-          ],
-          "tags": []
-        },
-        {
-          "alias": "Wear",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "1s"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "none"
-              ],
-              "type": "fill"
-            }
-          ],
-          "hide": false,
-          "measurement": "laps_cc",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"FuelData_FuelLeft\" and r._value >= 0)\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n      \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"FuelLeft\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-          "refId": "FuelLeft",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "telemetry_FrontLeftPercentWear"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "max"
-              }
-            ]
-          ],
-          "tags": []
-        }
-      ],
-      "title": "Fuel",
-      "transformations": [],
-      "transparent": true,
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "influxdb",
-        "uid": "${DS_RACING}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "orange",
-            "mode": "continuous-YlBl"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 12,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "noValue": "0",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "red"
-              },
-              {
-                "color": "green",
-                "value": 26
-              },
-              {
-                "color": "semi-dark-red",
-                "value": 27
-              }
-            ]
-          },
-          "unit": "pressurepsi"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byFrameRefID",
-              "options": "Oil"
-            },
-            "properties": [
-              {
-                "id": "custom.axisPlacement",
-                "value": "right"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "mode": "continuous-GrYlRd"
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 7,
-        "x": 17,
-        "y": 57
-      },
-      "id": 49,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "alias": "Tyre",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "1s"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "none"
-              ],
-              "type": "fill"
-            }
-          ],
-          "hide": false,
-          "measurement": "laps_cc",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"EngineData_EngineOilPressure\"and r._value >= 0)\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Oil\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-          "refId": "Oil",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "telemetry_FrontLeftPressure"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "max"
-              }
-            ]
-          ],
-          "tags": []
-        },
-        {
-          "alias": "Wear",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "1s"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "none"
-              ],
-              "type": "fill"
-            }
-          ],
-          "hide": false,
-          "measurement": "laps_cc",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"FuelData_FuelPressure\" and r._value >= 0)\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n      \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Fuel\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-          "refId": "Fuel",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "telemetry_FrontLeftPercentWear"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "max"
-              }
-            ]
-          ],
-          "tags": []
-        }
-      ],
-      "title": "Engine PSI",
-      "transformations": [],
-      "transparent": true,
-      "type": "timeseries"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 63
-      },
-      "id": 55,
-      "panels": [],
-      "title": "Weather Distance Flags",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "influxdb",
-        "uid": "${DS_RACING}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 16,
-            "gradientMode": "opacity",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "decimals": 2,
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "celsius"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byFrameRefID",
-              "options": "Rain"
-            },
-            "properties": [
-              {
-                "id": "custom.axisPlacement",
-                "value": "right"
-              },
-              {
-                "id": "unit",
-                "value": "humidity"
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 24,
-        "x": 0,
-        "y": 64
-      },
-      "id": 31,
-      "options": {
-        "legend": {
-          "calcs": [
-            "min",
-            "mean",
-            "max"
-          ],
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "alias": "Ambient Temp",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "1s"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "none"
-              ],
-              "type": "fill"
-            }
-          ],
-          "measurement": "laps_cc",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Conditions_Temperature_Ambient\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Ambient\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-          "refId": "Ambient",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "telemetry_AmbientTemperature"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "max"
-              }
-            ]
-          ],
-          "tags": []
-        },
-        {
-          "alias": "Track Temp",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "1s"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "none"
-              ],
-              "type": "fill"
-            }
-          ],
-          "hide": false,
-          "measurement": "laps_cc",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Conditions_Temperature_Track\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Track\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-          "refId": "Track",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "telemetry_TrackTemperature"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "mean"
-              }
-            ]
-          ],
-          "tags": []
-        },
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "hide": false,
-          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Conditions_RainDensity\" and r._value > 0)\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Rain Density\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-          "refId": "Rain"
-        }
-      ],
-      "title": "Temperature Conditions",
-      "transparent": true,
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "influxdb",
-        "uid": "${DS_RACING}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "fixed"
-          },
-          "custom": {
-            "axisCenteredZero": true,
-            "axisColorMode": "text",
-            "axisGridShow": true,
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "fillOpacity": 80,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineWidth": 2,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [
-            {
+              "id": "calculateField",
               "options": {
-                "1": {
-                  "color": "dark-green",
-                  "index": 0,
-                  "text": "Green"
+                "alias": "PSI",
+                "binary": {
+                  "left": "x10",
+                  "operator": "/",
+                  "reducer": "sum",
+                  "right": "70.3070"
                 },
-                "2": {
-                  "color": "dark-yellow",
-                  "index": 1,
-                  "text": "Yellow"
+                "mode": "binary",
+                "reduce": {
+                  "reducer": "sum"
                 },
-                "4": {
-                  "color": "dark-blue",
-                  "index": 2,
-                  "text": "Blue"
+                "replaceFields": false
+              }
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Tyre": true,
+                  "x10": true
                 },
-                "5": {
-                  "color": "#fbfbfb",
-                  "index": 3,
-                  "text": "White"
+                "indexByName": {},
+                "renameByName": {}
+              }
+            }
+          ],
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "orange",
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 12,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
                 },
-                "8": {
-                  "color": "#403f3f",
-                  "index": 4,
-                  "text": "Unknown/Finish"
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "area"
                 }
               },
-              "type": "value"
-            }
-          ],
-          "max": 1,
-          "noValue": "0",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
+              "decimals": 2,
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 26
+                  },
+                  {
+                    "color": "semi-dark-red",
+                    "value": 27
+                  }
+                ]
+              },
+              "unit": "pressurepsi"
+            },
+            "overrides": [
               {
-                "color": "green"
+                "matcher": {
+                  "id": "byName",
+                  "options": "Tyre"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "text",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "hidden"
+                  },
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": true,
+                      "tooltip": true,
+                      "viz": true
+                    }
+                  }
+                ]
               },
               {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Flag"
-            },
-            "properties": [
-              {
-                "id": "custom.axisPlacement",
-                "value": "hidden"
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 68
-      },
-      "id": 33,
-      "options": {
-        "barRadius": 0,
-        "barWidth": 0.97,
-        "colorByField": "Flag",
-        "fullHighlight": true,
-        "groupWidth": 0.7,
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "orientation": "vertical",
-        "showValue": "never",
-        "stacking": "percent",
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        },
-        "xField": "Time",
-        "xTickLabelMaxLength": 6,
-        "xTickLabelRotation": 0,
-        "xTickLabelSpacing": 100
-      },
-      "pluginVersion": "10.0.2",
-      "targets": [
-        {
-          "$$hashKey": "object:24",
-          "aggregation": "Last",
-          "alias": "Flag",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "decimals": 2,
-          "displayAliasType": "Warning / Critical",
-          "displayType": "Regular",
-          "displayValueWithAlias": "Never",
-          "groupBy": [
-            {
-              "params": [
-                "1s"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
-          ],
-          "measurement": "laps_cc",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Session_Flag\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value+1.0, _time:r._time, _field:\"Flag\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "telemetry_Flag"
-                ],
-                "type": "field"
+                "matcher": {
+                  "id": "byName",
+                  "options": "Wear"
+                },
+                "properties": [
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "right"
+                  },
+                  {
+                    "id": "unit",
+                    "value": "percent"
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green",
+                          "value": null
+                        },
+                        {
+                          "color": "#EAB839",
+                          "value": 60
+                        },
+                        {
+                          "color": "semi-dark-orange",
+                          "value": 70
+                        },
+                        {
+                          "color": "red",
+                          "value": 80
+                        },
+                        {
+                          "color": "dark-red",
+                          "value": 90
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "id": "max"
+                  },
+                  {
+                    "id": "custom.thresholdsStyle",
+                    "value": {
+                      "mode": "dashed"
+                    }
+                  },
+                  {
+                    "id": "min",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.scaleDistribution",
+                    "value": {
+                      "type": "linear"
+                    }
+                  }
+                ]
               },
               {
-                "params": [],
-                "type": "max"
-              }
-            ]
-          ],
-          "tags": [],
-          "units": "none",
-          "valueHandler": "Number Threshold"
-        }
-      ],
-      "title": "Flag",
-      "transformations": [],
-      "transparent": true,
-      "type": "barchart"
-    },
-    {
-      "datasource": {
-        "type": "influxdb",
-        "uid": "${DS_RACING}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "orange",
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 12,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "min": 0,
-          "noValue": "0",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "red"
-              },
-              {
-                "color": "green",
-                "value": 26
-              },
-              {
-                "color": "semi-dark-red",
-                "value": 27
+                "matcher": {
+                  "id": "byName",
+                  "options": "x10"
+                },
+                "properties": [
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "hidden"
+                  },
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": true,
+                      "tooltip": true,
+                      "viz": true
+                    }
+                  }
+                ]
               }
             ]
           },
-          "unit": "lengthm"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "%"
-            },
-            "properties": [
-              {
-                "id": "custom.axisPlacement",
-                "value": "right"
-              },
-              {
-                "id": "unit",
-                "value": "percentunit"
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 68
-      },
-      "id": 56,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "alias": "Tyre",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
+          "gridPos": {
+            "h": 5,
+            "w": 5,
+            "x": 19,
+            "y": 13
           },
-          "groupBy": [
-            {
-              "params": [
-                "1s"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "none"
-              ],
-              "type": "fill"
-            }
-          ],
-          "hide": false,
-          "measurement": "laps_cc",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"DistanceRoundTrack\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Distance\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-          "refId": "Distance",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "telemetry_FrontLeftPressure"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "max"
-              }
-            ]
-          ],
-          "tags": []
-        },
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_RACING}"
-          },
-          "hide": false,
-          "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Track_Length\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Track Length\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
-          "refId": "Track_Length"
-        }
-      ],
-      "title": "Distance in Meters",
-      "transformations": [
-        {
-          "id": "calculateField",
+          "id": 42,
           "options": {
-            "alias": "%",
-            "binary": {
-              "left": "Distance",
-              "operator": "/",
-              "reducer": "sum",
-              "right": "Track Length"
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
             },
-            "mode": "binary",
-            "reduce": {
-              "reducer": "sum"
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
             }
-          }
+          },
+          "targets": [
+            {
+              "alias": "Tyre",
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "groupBy": [
+                {
+                  "params": [
+                    "1s"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "none"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "hide": false,
+              "measurement": "laps_cc",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Front_Right_Pressure\"  and r._value >= 0)\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Tyre\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+              "refId": "TyrePressure",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "telemetry_FrontLeftPressure"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "max"
+                  }
+                ]
+              ],
+              "tags": []
+            },
+            {
+              "alias": "Wear",
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "groupBy": [
+                {
+                  "params": [
+                    "1s"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "none"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "hide": false,
+              "measurement": "laps_cc",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Front_Right_PercentWear\" and r._value >= 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n      \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Wear\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+              "refId": "TyreWear",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "telemetry_FrontLeftPercentWear"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "max"
+                  }
+                ]
+              ],
+              "tags": []
+            }
+          ],
+          "title": "Front Right (PSI-Wear)",
+          "transformations": [
+            {
+              "id": "calculateField",
+              "options": {
+                "alias": "x10",
+                "binary": {
+                  "left": "Tyre",
+                  "operator": "*",
+                  "reducer": "sum",
+                  "right": "10"
+                },
+                "mode": "binary",
+                "reduce": {
+                  "reducer": "sum"
+                }
+              }
+            },
+            {
+              "id": "calculateField",
+              "options": {
+                "alias": "PSI",
+                "binary": {
+                  "left": "x10",
+                  "operator": "/",
+                  "reducer": "sum",
+                  "right": "70.3070"
+                },
+                "mode": "binary",
+                "reduce": {
+                  "reducer": "sum"
+                },
+                "replaceFields": false
+              }
+            }
+          ],
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-RdYlGr"
+              },
+              "decimals": 0,
+              "mappings": [],
+              "min": -1,
+              "noValue": "0",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 2,
+            "x": 10,
+            "y": 17
+          },
+          "id": 23,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "auto"
+          },
+          "pluginVersion": "10.0.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "groupBy": [
+                {
+                  "params": [
+                    "1s"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "laps_cc",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Penalties_CutTrackWarnings\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: ${SessionLen}s, fn: max, createEmpty: false)\r\n\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Cuts\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "telemetry_CutTrackWarnings"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  }
+                ]
+              ],
+              "tags": []
+            }
+          ],
+          "title": "Cuts",
+          "transparent": true,
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-RdYlGr"
+              },
+              "decimals": 0,
+              "mappings": [],
+              "min": -1,
+              "noValue": "0",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 2,
+            "x": 12,
+            "y": 17
+          },
+          "id": 45,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "auto"
+          },
+          "pluginVersion": "10.0.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "groupBy": [
+                {
+                  "params": [
+                    "1s"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "laps_cc",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Penalties_Incidents\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: ${SessionLen}s, fn: max, createEmpty: false)\r\n\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Incidents\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "telemetry_CutTrackWarnings"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  }
+                ]
+              ],
+              "tags": []
+            }
+          ],
+          "title": "Incidents",
+          "transparent": true,
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "yellow",
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 40,
+                "gradientMode": "hue",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "area"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "dark-blue",
+                    "value": null
+                  },
+                  {
+                    "color": "dark-yellow",
+                    "value": 70
+                  },
+                  {
+                    "color": "dark-green",
+                    "value": 80
+                  },
+                  {
+                    "color": "dark-orange",
+                    "value": 90
+                  },
+                  {
+                    "color": "dark-red",
+                    "value": 100
+                  }
+                ]
+              },
+              "unit": "celsius"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byFrameRefID",
+                  "options": "BrakeTemp"
+                },
+                "properties": [
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "right"
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "light-blue",
+                          "value": null
+                        },
+                        {
+                          "color": "light-green",
+                          "value": 350
+                        },
+                        {
+                          "color": "light-red",
+                          "value": 650
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "id": "custom.scaleDistribution",
+                    "value": {
+                      "type": "linear"
+                    }
+                  },
+                  {
+                    "id": "custom.thresholdsStyle",
+                    "value": {
+                      "mode": "dashed"
+                    }
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 0
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 5,
+            "x": 0,
+            "y": 18
+          },
+          "id": 39,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "alias": "Core",
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "groupBy": [
+                {
+                  "params": [
+                    "1s"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "0"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "laps_cc",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Rear_Left_CenterTemp\" and r._value >= 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Tyre Core\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()\r\n ",
+              "refId": "TyreCore",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "telemetry_TyreData_Front_Left_CenterTemp"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "max"
+                  }
+                ]
+              ],
+              "tags": []
+            },
+            {
+              "alias": "Brake",
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "groupBy": [
+                {
+                  "params": [
+                    "1s"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "0"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "hide": false,
+              "measurement": "laps_cc",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Rear_Left_BrakeTemp\" and r._value >=0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Brake\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+              "refId": "BrakeTemp",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "telemetry_TyreData_Front_Left_BrakeTemp"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "max"
+                  }
+                ]
+              ],
+              "tags": []
+            }
+          ],
+          "title": "Rear Left Temp",
+          "transformations": [],
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "yellow",
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 40,
+                "gradientMode": "hue",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "area"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "dark-blue",
+                    "value": null
+                  },
+                  {
+                    "color": "dark-yellow",
+                    "value": 70
+                  },
+                  {
+                    "color": "dark-green",
+                    "value": 80
+                  },
+                  {
+                    "color": "dark-orange",
+                    "value": 90
+                  },
+                  {
+                    "color": "dark-red",
+                    "value": 100
+                  }
+                ]
+              },
+              "unit": "celsius"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byFrameRefID",
+                  "options": "BrakeTemp"
+                },
+                "properties": [
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "right"
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "light-blue",
+                          "value": null
+                        },
+                        {
+                          "color": "light-green",
+                          "value": 350
+                        },
+                        {
+                          "color": "light-red",
+                          "value": 650
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "id": "custom.scaleDistribution",
+                    "value": {
+                      "type": "linear"
+                    }
+                  },
+                  {
+                    "id": "custom.thresholdsStyle",
+                    "value": {
+                      "mode": "dashed"
+                    }
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 0
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 5,
+            "x": 5,
+            "y": 18
+          },
+          "id": 40,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "alias": "Core",
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "groupBy": [
+                {
+                  "params": [
+                    "1s"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "0"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "laps_cc",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Rear_Right_CenterTemp\" and r._value >= 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Tyre Core\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()\r\n ",
+              "refId": "TyreCore",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "telemetry_TyreData_Front_Left_CenterTemp"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "max"
+                  }
+                ]
+              ],
+              "tags": []
+            },
+            {
+              "alias": "Brake",
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "groupBy": [
+                {
+                  "params": [
+                    "1s"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "0"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "hide": false,
+              "measurement": "laps_cc",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Rear_Right_BrakeTemp\" and r._value >=0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Brake\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+              "refId": "BrakeTemp",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "telemetry_TyreData_Front_Left_BrakeTemp"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "max"
+                  }
+                ]
+              ],
+              "tags": []
+            }
+          ],
+          "title": "Rear Right Temp",
+          "transformations": [],
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "orange",
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 12,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "area"
+                }
+              },
+              "decimals": 2,
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 26
+                  },
+                  {
+                    "color": "semi-dark-red",
+                    "value": 27
+                  }
+                ]
+              },
+              "unit": "pressurepsi"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Tyre"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "text",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "hidden"
+                  },
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": true,
+                      "tooltip": true,
+                      "viz": true
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Wear"
+                },
+                "properties": [
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "right"
+                  },
+                  {
+                    "id": "unit",
+                    "value": "percent"
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green",
+                          "value": null
+                        },
+                        {
+                          "color": "yellow",
+                          "value": 60
+                        },
+                        {
+                          "color": "semi-dark-orange",
+                          "value": 70
+                        },
+                        {
+                          "color": "red",
+                          "value": 80
+                        },
+                        {
+                          "color": "dark-red",
+                          "value": 90
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "id": "max"
+                  },
+                  {
+                    "id": "custom.thresholdsStyle",
+                    "value": {
+                      "mode": "dashed"
+                    }
+                  },
+                  {
+                    "id": "min",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.scaleDistribution",
+                    "value": {
+                      "type": "linear"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "x10"
+                },
+                "properties": [
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "hidden"
+                  },
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": true,
+                      "tooltip": true,
+                      "viz": true
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 5,
+            "x": 14,
+            "y": 18
+          },
+          "id": 43,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "alias": "Tyre",
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "groupBy": [
+                {
+                  "params": [
+                    "1s"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "none"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "hide": false,
+              "measurement": "laps_cc",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Rear_Left_Pressure\" and r._value >= 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Tyre\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+              "refId": "TyrePressure",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "telemetry_FrontLeftPressure"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "max"
+                  }
+                ]
+              ],
+              "tags": []
+            },
+            {
+              "alias": "Wear",
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "groupBy": [
+                {
+                  "params": [
+                    "1s"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "none"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "hide": false,
+              "measurement": "laps_cc",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Rear_Left_PercentWear\" and r._value >= 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n      \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Wear\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+              "refId": "TyreWear",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "telemetry_FrontLeftPercentWear"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "max"
+                  }
+                ]
+              ],
+              "tags": []
+            }
+          ],
+          "title": "Rear Left (PSI-Wear)",
+          "transformations": [
+            {
+              "id": "calculateField",
+              "options": {
+                "alias": "x10",
+                "binary": {
+                  "left": "Tyre",
+                  "operator": "*",
+                  "reducer": "sum",
+                  "right": "10"
+                },
+                "mode": "binary",
+                "reduce": {
+                  "reducer": "sum"
+                }
+              }
+            },
+            {
+              "id": "calculateField",
+              "options": {
+                "alias": "PSI",
+                "binary": {
+                  "left": "x10",
+                  "operator": "/",
+                  "reducer": "sum",
+                  "right": "70.3070"
+                },
+                "mode": "binary",
+                "reduce": {
+                  "reducer": "sum"
+                },
+                "replaceFields": false
+              }
+            }
+          ],
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "orange",
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 12,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "area"
+                }
+              },
+              "decimals": 2,
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 26
+                  },
+                  {
+                    "color": "semi-dark-red",
+                    "value": 27
+                  }
+                ]
+              },
+              "unit": "pressurepsi"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Tyre"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "text",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "hidden"
+                  },
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": true,
+                      "tooltip": true,
+                      "viz": true
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Wear"
+                },
+                "properties": [
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "right"
+                  },
+                  {
+                    "id": "unit",
+                    "value": "percent"
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green",
+                          "value": null
+                        },
+                        {
+                          "color": "yellow",
+                          "value": 60
+                        },
+                        {
+                          "color": "semi-dark-orange",
+                          "value": 70
+                        },
+                        {
+                          "color": "red",
+                          "value": 80
+                        },
+                        {
+                          "color": "dark-red",
+                          "value": 90
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "id": "max"
+                  },
+                  {
+                    "id": "custom.thresholdsStyle",
+                    "value": {
+                      "mode": "dashed"
+                    }
+                  },
+                  {
+                    "id": "min",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.scaleDistribution",
+                    "value": {
+                      "type": "linear"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "x10"
+                },
+                "properties": [
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "hidden"
+                  },
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": true,
+                      "tooltip": true,
+                      "viz": true
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 5,
+            "x": 19,
+            "y": 18
+          },
+          "id": 44,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "alias": "Tyre",
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "groupBy": [
+                {
+                  "params": [
+                    "1s"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "none"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "hide": false,
+              "measurement": "laps_cc",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Rear_Right_Pressure\" and r._value >= 0)\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Tyre\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+              "refId": "TyrePressure",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "telemetry_FrontLeftPressure"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "max"
+                  }
+                ]
+              ],
+              "tags": []
+            },
+            {
+              "alias": "Wear",
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "groupBy": [
+                {
+                  "params": [
+                    "1s"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "none"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "hide": false,
+              "measurement": "laps_cc",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"TyreData_Rear_Right_PercentWear\"  and r._value >= 0)\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n      \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Wear\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+              "refId": "TyreWear",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "telemetry_FrontLeftPercentWear"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "max"
+                  }
+                ]
+              ],
+              "tags": []
+            }
+          ],
+          "title": "Rear Right (PSI-Wear)",
+          "transformations": [
+            {
+              "id": "calculateField",
+              "options": {
+                "alias": "x10",
+                "binary": {
+                  "left": "Tyre",
+                  "operator": "*",
+                  "reducer": "sum",
+                  "right": "10"
+                },
+                "mode": "binary",
+                "reduce": {
+                  "reducer": "sum"
+                }
+              }
+            },
+            {
+              "id": "calculateField",
+              "options": {
+                "alias": "PSI",
+                "binary": {
+                  "left": "x10",
+                  "operator": "/",
+                  "reducer": "sum",
+                  "right": "70.3070"
+                },
+                "mode": "binary",
+                "reduce": {
+                  "reducer": "sum"
+                },
+                "replaceFields": false
+              }
+            }
+          ],
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-RdYlGr"
+              },
+              "decimals": 0,
+              "mappings": [],
+              "min": -1,
+              "noValue": "0",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 2,
+            "x": 10,
+            "y": 20
+          },
+          "id": 46,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "auto"
+          },
+          "pluginVersion": "10.0.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "groupBy": [
+                {
+                  "params": [
+                    "1s"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "laps_cc",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Penalties_Total\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: ${SessionLen}s, fn: max, createEmpty: false)\r\n\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Penalties\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "telemetry_CutTrackWarnings"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  }
+                ]
+              ],
+              "tags": []
+            }
+          ],
+          "title": "Penalties",
+          "transparent": true,
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "decimals": 0,
+              "mappings": [],
+              "noValue": "0",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 0.1
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 0.25
+                  },
+                  {
+                    "color": "#88bf69",
+                    "value": 0.5
+                  },
+                  {
+                    "color": "dark-green",
+                    "value": 0.6
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 2,
+            "x": 12,
+            "y": 20
+          },
+          "id": 51,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "center",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "/^Fuel%$/",
+              "values": false
+            },
+            "textMode": "value"
+          },
+          "pluginVersion": "10.0.2",
+          "targets": [
+            {
+              "alias": "Tyre",
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "groupBy": [
+                {
+                  "params": [
+                    "1s"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "none"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "hide": false,
+              "measurement": "laps_cc",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"FuelData_FuelCapacity\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"FuelCapacity\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+              "refId": "FuelCapacity",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "telemetry_FrontLeftPressure"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "max"
+                  }
+                ]
+              ],
+              "tags": []
+            },
+            {
+              "alias": "Wear",
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "groupBy": [
+                {
+                  "params": [
+                    "1s"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "none"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "hide": false,
+              "measurement": "laps_cc",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"FuelData_FuelLeft\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n      \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"FuelLeft\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+              "refId": "FuelLeft",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "telemetry_FrontLeftPercentWear"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "max"
+                  }
+                ]
+              ],
+              "tags": []
+            }
+          ],
+          "title": "Fuel %",
+          "transformations": [
+            {
+              "id": "calculateField",
+              "options": {
+                "alias": "Fuel%",
+                "binary": {
+                  "left": "FuelLeft",
+                  "operator": "/",
+                  "reducer": "sum",
+                  "right": "FuelCapacity"
+                },
+                "mode": "binary",
+                "reduce": {
+                  "reducer": "sum"
+                },
+                "replaceFields": true
+              }
+            }
+          ],
+          "transparent": true,
+          "type": "stat"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 23
+          },
+          "id": 4,
+          "panels": [],
+          "title": "Time Speed Inputs",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "purple",
+                "mode": "fixed"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "Lap time",
+                "axisPlacement": "left",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 51,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "1": {
+                      "color": "green",
+                      "index": 0
+                    },
+                    "2": {
+                      "color": "purple",
+                      "index": 1
+                    },
+                    "3": {
+                      "color": "yellow",
+                      "index": 2
+                    },
+                    "4": {
+                      "color": "#a5f700",
+                      "index": 3
+                    },
+                    "5": {
+                      "color": "semi-dark-blue",
+                      "index": 4
+                    },
+                    "6": {
+                      "color": "#ba05f7",
+                      "index": 5
+                    },
+                    "7": {
+                      "color": "#0affb9",
+                      "index": 6
+                    }
+                  },
+                  "type": "value"
+                }
+              ],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "clocks"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byFrameRefID",
+                  "options": "Lap"
+                },
+                "properties": [
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "right"
+                  },
+                  {
+                    "id": "custom.axisLabel",
+                    "value": "Laps Num"
+                  },
+                  {
+                    "id": "unit",
+                    "value": "none"
+                  },
+                  {
+                    "id": "custom.scaleDistribution",
+                    "value": {
+                      "type": "linear"
+                    }
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.lineWidth",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 0
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "dark-yellow",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 10,
+            "x": 0,
+            "y": 24
+          },
+          "id": 18,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "alias": "Last Lap",
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "groupBy": [
+                {
+                  "params": [
+                    "1s"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "laps_cc",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"LapTimePrevious\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Lap Valid Time\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+              "refId": "LapTime",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "telemetry_LapTimePrevious"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "max"
+                  }
+                ]
+              ],
+              "tags": []
+            },
+            {
+              "alias": "Lap",
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "hide": false,
+              "measurement": "laps_cc",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"CurrentLap\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Lap #\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+              "refId": "Lap",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "telemetry_CurrentLap"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "mean"
+                  }
+                ]
+              ],
+              "tags": []
+            }
+          ],
+          "title": "Last Lap",
+          "transparent": true,
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "#be60f2",
+                "mode": "fixed"
+              },
+              "decimals": 0,
+              "mappings": [],
+              "noValue": "0",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "light-red",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 4,
+            "x": 10,
+            "y": 24
+          },
+          "id": 6,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "center",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "value_and_name"
+          },
+          "pluginVersion": "10.0.2",
+          "targets": [
+            {
+              "alias": "maxspeedms",
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "groupBy": [
+                {
+                  "params": [
+                    "1m"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "0"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "hide": false,
+              "measurement": "laps_cc",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"SpeedMs\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1d, fn: max, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"maxspeedms\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "telemetry_SpeedMs"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "max"
+                  }
+                ]
+              ],
+              "tags": []
+            }
+          ],
+          "title": "Top Speed",
+          "transformations": [
+            {
+              "id": "calculateField",
+              "options": {
+                "alias": "${Speed:text}",
+                "binary": {
+                  "left": "_value",
+                  "operator": "*",
+                  "reducer": "sum",
+                  "right": "${Speed}"
+                },
+                "mode": "binary",
+                "reduce": {
+                  "include": [
+                    "laps_cc.last"
+                  ],
+                  "reducer": "sum"
+                },
+                "replaceFields": true
+              }
+            }
+          ],
+          "transparent": true,
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "log": 2,
+                  "type": "symlog"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byFrameRefID",
+                  "options": "B"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Delta Behind"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byFrameRefID",
+                  "options": "A"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Delta Front"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 10,
+            "x": 14,
+            "y": 24
+          },
+          "id": 20,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean"
+              ],
+              "displayMode": "list",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "alias": "Delta Front",
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "groupBy": [
+                {
+                  "params": [
+                    "1s"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "laps_cc",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Session_Delta_Front\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Delta_Front\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "telemetry_DeltaFront"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "max"
+                  }
+                ]
+              ],
+              "tags": []
+            },
+            {
+              "alias": "Delta Behind",
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "groupBy": [
+                {
+                  "params": [
+                    "1s"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "0"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "hide": false,
+              "measurement": "laps_cc",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Session_Delta_Behind\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Delta_Behind\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+              "refId": "B",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "telemetry_DeltaBehind"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "max"
+                  }
+                ]
+              ],
+              "tags": []
+            }
+          ],
+          "title": "Deltas",
+          "transparent": true,
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "left",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "gradientMode": "opacity",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "SpeedMs"
+                },
+                "properties": [
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": true,
+                      "tooltip": true,
+                      "viz": true
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Sector"
+                },
+                "properties": [
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "right"
+                  },
+                  {
+                    "id": "displayName",
+                    "value": "Sector"
+                  },
+                  {
+                    "id": "max",
+                    "value": 3
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "dark-yellow",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 0
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "PitLimitMs"
+                },
+                "properties": [
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": true,
+                      "tooltip": true,
+                      "viz": true
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Km/h"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "dark-blue",
+                      "mode": "shades"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 24,
+            "x": 0,
+            "y": 29
+          },
+          "id": 16,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "9.4.7",
+          "targets": [
+            {
+              "alias": "maxspeedms",
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "groupBy": [
+                {
+                  "params": [
+                    "1s"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "hide": false,
+              "measurement": "laps_cc",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"SpeedMs\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"SpeedMs\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+              "refId": "SpeedMs",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "telemetry_SpeedMs"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "max"
+                  }
+                ]
+              ],
+              "tags": []
+            },
+            {
+              "alias": "Section",
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "groupBy": [
+                {
+                  "params": [
+                    "1s"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "hide": false,
+              "measurement": "laps_cc",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"PitData_PitSpeedLimit\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"PitLimitMs\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+              "refId": "PitLimit",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "telemetry_Sector"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "max"
+                  }
+                ]
+              ],
+              "tags": []
+            },
+            {
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "hide": false,
+              "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Session_Sector\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Sector\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+              "refId": "Sector"
+            }
+          ],
+          "title": "Speed",
+          "transformations": [
+            {
+              "id": "calculateField",
+              "options": {
+                "alias": "${Speed:text}",
+                "binary": {
+                  "left": "SpeedMs",
+                  "operator": "*",
+                  "reducer": "sum",
+                  "right": "${Speed}"
+                },
+                "mode": "binary",
+                "reduce": {
+                  "include": [
+                    "laps_cc.last"
+                  ],
+                  "reducer": "sum"
+                },
+                "replaceFields": false
+              }
+            },
+            {
+              "id": "calculateField",
+              "options": {
+                "alias": "Pit Limit",
+                "binary": {
+                  "left": "PitLimitMs",
+                  "operator": "*",
+                  "reducer": "sum",
+                  "right": "${Speed}"
+                },
+                "mode": "binary",
+                "reduce": {
+                  "reducer": "sum"
+                }
+              }
+            }
+          ],
+          "transparent": true,
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 2,
+                "gradientMode": "scheme",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byFrameRefID",
+                  "options": "SteeringAngle"
+                },
+                "properties": [
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "right"
+                  },
+                  {
+                    "id": "unit",
+                    "value": "none"
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 22
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "super-light-orange",
+                      "mode": "fixed",
+                      "seriesBy": "min"
+                    }
+                  },
+                  {
+                    "id": "displayName",
+                    "value": "SteeringAngle"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byFrameRefID",
+                  "options": "Brake"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "dark-red",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "displayName",
+                    "value": "Brake"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byFrameRefID",
+                  "options": "Throttle"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "dark-green",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "displayName",
+                    "value": "Throttle"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byFrameRefID",
+                  "options": "Clutch"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Clutch"
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "orange",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 2
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byFrameRefID",
+                  "options": "Handbrake"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Handbrake"
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "dark-blue",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 24,
+            "x": 0,
+            "y": 35
+          },
+          "id": 2,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "alias": "Brake",
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "groupBy": [
+                {
+                  "params": [
+                    "1s"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "0"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "hide": false,
+              "measurement": "laps_cc",
+              "orderByTime": "ASC",
+              "policy": "autogen",
+              "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Brake\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: last, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n  |> set(key: \"_field\", value: \"Brake\")\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Brake\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+              "refId": "Brake",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "telemetry_Brake"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  }
+                ]
+              ],
+              "tags": []
+            },
+            {
+              "alias": "Throttle",
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "groupBy": [
+                {
+                  "params": [
+                    "1s"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "0"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "hide": false,
+              "measurement": "laps_cc",
+              "orderByTime": "ASC",
+              "policy": "autogen",
+              "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Throttle\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: last, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n  |> set(key: \"_field\", value: \"Throttle\")\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Throttle\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+              "refId": "Throttle",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "telemetry_Throttle"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  }
+                ]
+              ],
+              "tags": []
+            },
+            {
+              "alias": "Steer",
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "groupBy": [
+                {
+                  "params": [
+                    "1s"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "linear"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "hide": false,
+              "measurement": "laps_cc",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"SteeringAngle\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: last, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n  |> set(key: \"_field\", value: \"SteeringAngle\")\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"SteeringAngle\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+              "refId": "SteeringAngle",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "telemetry_SteeringAngle"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "max"
+                  }
+                ]
+              ],
+              "tags": []
+            },
+            {
+              "alias": "Throttle",
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "groupBy": [
+                {
+                  "params": [
+                    "1s"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "0"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "hide": false,
+              "measurement": "laps_cc",
+              "orderByTime": "ASC",
+              "policy": "autogen",
+              "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Clutch\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: last, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n  |> set(key: \"_field\", value: \"Clutch\")\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Clutch\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+              "refId": "Clutch",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "telemetry_Throttle"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  }
+                ]
+              ],
+              "tags": []
+            },
+            {
+              "alias": "Throttle",
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "groupBy": [
+                {
+                  "params": [
+                    "1s"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "0"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "hide": false,
+              "measurement": "laps_cc",
+              "orderByTime": "ASC",
+              "policy": "autogen",
+              "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Handbrake\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: last, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n  |> set(key: \"_field\", value: \"Handbrake\")\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Handbrake\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+              "refId": "Handbrake",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "telemetry_Throttle"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  }
+                ]
+              ],
+              "tags": []
+            }
+          ],
+          "title": "Inputs",
+          "transparent": true,
+          "type": "timeseries"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 44
+          },
+          "id": 52,
+          "panels": [],
+          "title": "Engine Data ",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "series",
+                "axisLabel": "RPMs",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "decimals": 0,
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byFrameRefID",
+                  "options": "Gear"
+                },
+                "properties": [
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "right"
+                  },
+                  {
+                    "id": "displayName",
+                    "value": "Gear"
+                  },
+                  {
+                    "id": "custom.axisLabel",
+                    "value": "Gears"
+                  },
+                  {
+                    "id": "custom.lineInterpolation",
+                    "value": "stepBefore"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byFrameRefID",
+                  "options": "RPM"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "RPM"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byFrameRefID",
+                  "options": "MaxRPM"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Max RPM"
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "dark-red",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 24,
+            "x": 0,
+            "y": 45
+          },
+          "id": 35,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "groupBy": [
+                {
+                  "params": [
+                    "1s"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "none"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "laps_cc",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"EngineData_EngineRpm\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n  |> set(key: \"_field\", value: \"EngineData_EngineRpm\")\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"EngineData_EngineRpm\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+              "refId": "RPM",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "telemetry_Rpms"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "max"
+                  }
+                ]
+              ],
+              "tags": []
+            },
+            {
+              "alias": "Gear",
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "groupBy": [
+                {
+                  "params": [
+                    "1s"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "none"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "hide": false,
+              "measurement": "laps_cc",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Gear\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: last, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n  |> set(key: \"_field\", value: \"Gear\")\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Gear\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+              "refId": "Gear",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "telemetry_Gear"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "max"
+                  }
+                ]
+              ],
+              "tags": []
+            },
+            {
+              "alias": "Max",
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "groupBy": [
+                {
+                  "params": [
+                    "1s"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "none"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "hide": false,
+              "measurement": "laps_cc",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"EngineData_MaxEngineRpm\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n  |> set(key: \"_field\", value: \"EngineData_MaxEngineRpm\")\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"EngineData_MaxEngineRpm\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+              "refId": "MaxRPM",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "telemetry_EngineData_MaxEngineRpm"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "max"
+                  }
+                ]
+              ],
+              "tags": []
+            }
+          ],
+          "title": "Engine RPMs",
+          "transformations": [],
+          "transparent": true,
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds",
+                "seriesBy": "last"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "series",
+                "axisLabel": "%",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "area"
+                }
+              },
+              "decimals": 0,
+              "mappings": [],
+              "max": 1,
+              "noValue": "0",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "super-light-yellow"
+                  },
+                  {
+                    "color": "light-blue",
+                    "value": 0
+                  },
+                  {
+                    "color": "dark-green",
+                    "value": 0.55
+                  },
+                  {
+                    "color": "dark-red",
+                    "value": 0.9
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 24,
+            "x": 0,
+            "y": 51
+          },
+          "id": 47,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "groupBy": [
+                {
+                  "params": [
+                    "1s"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "none"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "laps_cc",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"EngineData_EngineRpm\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n  |> set(key: \"_field\", value: \"EngineData_EngineRpm\")\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"EngineData_EngineRpm\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+              "refId": "RPM",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "telemetry_Rpms"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "max"
+                  }
+                ]
+              ],
+              "tags": []
+            },
+            {
+              "alias": "Max",
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "groupBy": [
+                {
+                  "params": [
+                    "1s"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "none"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "hide": false,
+              "measurement": "laps_cc",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"EngineData_MaxEngineRpm\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"SessionId\",\"_value\",\"_time\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n  |> group(columns: [\"SessionId\"])\r\n  |> set(key: \"_field\", value: \"EngineData_MaxEngineRpm\")\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"EngineData_MaxEngineRpm\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+              "refId": "MaxRPM",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "telemetry_EngineData_MaxEngineRpm"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "max"
+                  }
+                ]
+              ],
+              "tags": []
+            }
+          ],
+          "title": "Engine RPM %",
+          "transformations": [
+            {
+              "id": "calculateField",
+              "options": {
+                "alias": "%RPM",
+                "binary": {
+                  "left": "_value 1",
+                  "operator": "/",
+                  "reducer": "sum",
+                  "right": "_value 2"
+                },
+                "mode": "binary",
+                "reduce": {
+                  "reducer": "sum"
+                },
+                "replaceFields": true
+              }
+            }
+          ],
+          "transparent": true,
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "yellow",
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 12,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "area"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "dark-blue"
+                  },
+                  {
+                    "color": "dark-yellow",
+                    "value": 70
+                  },
+                  {
+                    "color": "dark-green",
+                    "value": 80
+                  },
+                  {
+                    "color": "dark-orange",
+                    "value": 100
+                  },
+                  {
+                    "color": "dark-red",
+                    "value": 143
+                  }
+                ]
+              },
+              "unit": "celsius"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byFrameRefID",
+                  "options": "EngineOilTemp"
+                },
+                "properties": [
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "right"
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "blue"
+                        },
+                        {
+                          "color": "light-green",
+                          "value": 82
+                        },
+                        {
+                          "color": "orange",
+                          "value": 104
+                        },
+                        {
+                          "color": "red",
+                          "value": 140
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "id": "custom.scaleDistribution",
+                    "value": {
+                      "type": "linear"
+                    }
+                  },
+                  {
+                    "id": "custom.thresholdsStyle",
+                    "value": {
+                      "mode": "dashed"
+                    }
+                  },
+                  {
+                    "id": "displayName",
+                    "value": "Oil"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byFrameRefID",
+                  "options": "WaterTemp"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Water"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 9,
+            "x": 0,
+            "y": 57
+          },
+          "id": 48,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "alias": "Core",
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "groupBy": [
+                {
+                  "params": [
+                    "1s"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "0"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "laps_cc",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"EngineData_EngineWaterTemp\" and r._value >=0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"EngineData_EngineWaterTemp\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()\r\n ",
+              "refId": "WaterTemp",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "telemetry_TyreData_Front_Left_CenterTemp"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "max"
+                  }
+                ]
+              ],
+              "tags": []
+            },
+            {
+              "alias": "Brake",
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "groupBy": [
+                {
+                  "params": [
+                    "1s"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "0"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "hide": false,
+              "measurement": "laps_cc",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"EngineData_EngineOilTemp\" and r._value >= 0)\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n\r\n\r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"EngineData_EngineOilTemp\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+              "refId": "EngineOilTemp",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "telemetry_TyreData_Front_Left_BrakeTemp"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "max"
+                  }
+                ]
+              ],
+              "tags": []
+            }
+          ],
+          "title": "Engine Temps",
+          "transformations": [],
+          "transparent": true,
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "orange",
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 12,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "min": 0,
+              "noValue": "0",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red"
+                  },
+                  {
+                    "color": "green",
+                    "value": 26
+                  },
+                  {
+                    "color": "semi-dark-red",
+                    "value": 27
+                  }
+                ]
+              },
+              "unit": "litre"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 8,
+            "x": 9,
+            "y": 57
+          },
+          "id": 50,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "alias": "Tyre",
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "groupBy": [
+                {
+                  "params": [
+                    "1s"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "none"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "hide": false,
+              "measurement": "laps_cc",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"FuelData_FuelCapacity\" and r._value >= 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"FuelCapacity\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+              "refId": "FuelCapacity",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "telemetry_FrontLeftPressure"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "max"
+                  }
+                ]
+              ],
+              "tags": []
+            },
+            {
+              "alias": "Wear",
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "groupBy": [
+                {
+                  "params": [
+                    "1s"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "none"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "hide": false,
+              "measurement": "laps_cc",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"FuelData_FuelLeft\" and r._value >= 0)\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n      \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"FuelLeft\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+              "refId": "FuelLeft",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "telemetry_FrontLeftPercentWear"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "max"
+                  }
+                ]
+              ],
+              "tags": []
+            }
+          ],
+          "title": "Fuel",
+          "transformations": [],
+          "transparent": true,
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "orange",
+                "mode": "continuous-YlBl"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 12,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "noValue": "0",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red"
+                  },
+                  {
+                    "color": "green",
+                    "value": 26
+                  },
+                  {
+                    "color": "semi-dark-red",
+                    "value": 27
+                  }
+                ]
+              },
+              "unit": "pressurepsi"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byFrameRefID",
+                  "options": "Oil"
+                },
+                "properties": [
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "right"
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "mode": "continuous-GrYlRd"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 7,
+            "x": 17,
+            "y": 57
+          },
+          "id": 49,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "alias": "Tyre",
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "groupBy": [
+                {
+                  "params": [
+                    "1s"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "none"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "hide": false,
+              "measurement": "laps_cc",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"EngineData_EngineOilPressure\"and r._value >= 0)\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Oil\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+              "refId": "Oil",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "telemetry_FrontLeftPressure"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "max"
+                  }
+                ]
+              ],
+              "tags": []
+            },
+            {
+              "alias": "Wear",
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "groupBy": [
+                {
+                  "params": [
+                    "1s"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "none"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "hide": false,
+              "measurement": "laps_cc",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"FuelData_FuelPressure\" and r._value >= 0)\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n      \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Fuel\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+              "refId": "Fuel",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "telemetry_FrontLeftPercentWear"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "max"
+                  }
+                ]
+              ],
+              "tags": []
+            }
+          ],
+          "title": "Engine PSI",
+          "transformations": [],
+          "transparent": true,
+          "type": "timeseries"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 63
+          },
+          "id": 55,
+          "panels": [],
+          "title": "Weather Distance Flags",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 16,
+                "gradientMode": "opacity",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "decimals": 2,
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "celsius"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byFrameRefID",
+                  "options": "Rain"
+                },
+                "properties": [
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "right"
+                  },
+                  {
+                    "id": "unit",
+                    "value": "humidity"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 24,
+            "x": 0,
+            "y": 64
+          },
+          "id": 31,
+          "options": {
+            "legend": {
+              "calcs": [
+                "min",
+                "mean",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "alias": "Ambient Temp",
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "groupBy": [
+                {
+                  "params": [
+                    "1s"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "none"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "laps_cc",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Conditions_Temperature_Ambient\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Ambient\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+              "refId": "Ambient",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "telemetry_AmbientTemperature"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "max"
+                  }
+                ]
+              ],
+              "tags": []
+            },
+            {
+              "alias": "Track Temp",
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "groupBy": [
+                {
+                  "params": [
+                    "1s"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "none"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "hide": false,
+              "measurement": "laps_cc",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Conditions_Temperature_Track\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Track\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+              "refId": "Track",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "telemetry_TrackTemperature"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "mean"
+                  }
+                ]
+              ],
+              "tags": []
+            },
+            {
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "hide": false,
+              "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Conditions_RainDensity\" and r._value > 0)\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Rain Density\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+              "refId": "Rain"
+            }
+          ],
+          "title": "Temperature Conditions",
+          "transparent": true,
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "fixed"
+              },
+              "custom": {
+                "axisCenteredZero": true,
+                "axisColorMode": "text",
+                "axisGridShow": true,
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineWidth": 2,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "1": {
+                      "color": "dark-green",
+                      "index": 0,
+                      "text": "Green"
+                    },
+                    "2": {
+                      "color": "dark-yellow",
+                      "index": 1,
+                      "text": "Yellow"
+                    },
+                    "4": {
+                      "color": "dark-blue",
+                      "index": 2,
+                      "text": "Blue"
+                    },
+                    "5": {
+                      "color": "#fbfbfb",
+                      "index": 3,
+                      "text": "White"
+                    },
+                    "8": {
+                      "color": "#403f3f",
+                      "index": 4,
+                      "text": "Unknown/Finish"
+                    }
+                  },
+                  "type": "value"
+                }
+              ],
+              "max": 1,
+              "noValue": "0",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Flag"
+                },
+                "properties": [
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "hidden"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 68
+          },
+          "id": 33,
+          "options": {
+            "barRadius": 0,
+            "barWidth": 0.97,
+            "colorByField": "Flag",
+            "fullHighlight": true,
+            "groupWidth": 0.7,
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "orientation": "vertical",
+            "showValue": "never",
+            "stacking": "percent",
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            },
+            "xField": "Time",
+            "xTickLabelMaxLength": 6,
+            "xTickLabelRotation": 0,
+            "xTickLabelSpacing": 100
+          },
+          "pluginVersion": "10.0.2",
+          "targets": [
+            {
+              "$$hashKey": "object:24",
+              "aggregation": "Last",
+              "alias": "Flag",
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "decimals": 2,
+              "displayAliasType": "Warning / Critical",
+              "displayType": "Regular",
+              "displayValueWithAlias": "Never",
+              "groupBy": [
+                {
+                  "params": [
+                    "1s"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "laps_cc",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Session_Flag\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value+1.0, _time:r._time, _field:\"Flag\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "telemetry_Flag"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "max"
+                  }
+                ]
+              ],
+              "tags": [],
+              "units": "none",
+              "valueHandler": "Number Threshold"
+            }
+          ],
+          "title": "Flag",
+          "transformations": [],
+          "transparent": true,
+          "type": "barchart"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_RACING}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "orange",
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 12,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "min": 0,
+              "noValue": "0",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red"
+                  },
+                  {
+                    "color": "green",
+                    "value": 26
+                  },
+                  {
+                    "color": "semi-dark-red",
+                    "value": 27
+                  }
+                ]
+              },
+              "unit": "lengthm"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "%"
+                },
+                "properties": [
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "right"
+                  },
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 68
+          },
+          "id": 56,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "alias": "Tyre",
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "groupBy": [
+                {
+                  "params": [
+                    "1s"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "none"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "hide": false,
+              "measurement": "laps_cc",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"DistanceRoundTrack\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Distance\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+              "refId": "Distance",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "telemetry_FrontLeftPressure"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "max"
+                  }
+                ]
+              ],
+              "tags": []
+            },
+            {
+              "datasource": {
+                "type": "influxdb",
+                "uid": "${DS_RACING}"
+              },
+              "hide": false,
+              "query": "import \"date\"\r\nFinalOutput = [\"_field\", \"_time\", \"_value\"]\r\nStartSession =  time (v: ${SessionStart})\r\nStopSession  = time (v: ${SessionEnd})\r\n\r\nRawSeries = from(bucket: \"racing\")\r\n  |> range(start: StartSession, stop: StopSession)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r._field == \"Track_Length\" )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> keep(columns: [\"CarModel\", \"_field\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> group(columns: [\"_field\"])\r\n  |> aggregateWindow(every: 1s, fn: max, createEmpty: false)\r\n     \r\nNamedSeries = RawSeries\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time, _field:\"Track Length\"}))\r\n  |> keep(columns:FinalOutput)\r\n\r\nNamedSeries |> yield()",
+              "refId": "Track_Length"
+            }
+          ],
+          "title": "Distance in Meters",
+          "transformations": [
+            {
+              "id": "calculateField",
+              "options": {
+                "alias": "%",
+                "binary": {
+                  "left": "Distance",
+                  "operator": "/",
+                  "reducer": "sum",
+                  "right": "Track Length"
+                },
+                "mode": "binary",
+                "reduce": {
+                  "reducer": "sum"
+                }
+              }
+            }
+          ],
+          "transparent": true,
+          "type": "timeseries"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 76
+          },
+          "id": 57,
+          "panels": [],
+          "title": "Work In Progress",
+          "type": "row"
         }
       ],
-      "transparent": true,
-      "type": "timeseries"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 76
+      "refresh": "",
+      "revision": 1,
+      "schemaVersion": 38,
+      "style": "dark",
+      "tags": [],
+      "templating": {
+        "list": [
+          {
+            "current": {
+              "selected": false,
+              "text": "Racing",
+              "value": "Racing"
+            },
+            "hide": 2,
+            "includeAll": false,
+            "multi": false,
+            "name": "DS_RACING",
+            "options": [],
+            "query": "influxdb",
+            "queryValue": "",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "type": "datasource"
+          },
+          {
+            "current": {
+              "selected": true,
+              "text": "Km/h",
+              "value": "3.6"
+            },
+            "hide": 0,
+            "includeAll": false,
+            "label": "Speed",
+            "multi": false,
+            "name": "Speed",
+            "options": [
+              {
+                "selected": true,
+                "text": "Km/h",
+                "value": "3.6"
+              },
+              {
+                "selected": false,
+                "text": "MPH",
+                "value": "2.236936292054"
+              }
+            ],
+            "query": "Km/h : 3.6 , MPH : 2.236936292054",
+            "queryValue": "",
+            "skipUrlSync": false,
+            "type": "custom"
+          },
+          {
+            "current": {
+              "selected": false,
+              "text": "e Grant",
+              "value": "e Grant"
+            },
+            "datasource": {
+              "type": "influxdb",
+              "uid": "${DS_RACING}"
+            },
+            "definition": "from(bucket: \"racing\")\r\n  |> range(start: -1y, stop: now())\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"Gear\")\r\n  |> keep(columns: [\"user\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> first()\r\n  |> group(columns: [])\r\n  |> drop(columns: [\"_value\",\"_time\"])",
+            "hide": 0,
+            "includeAll": false,
+            "multi": false,
+            "name": "User",
+            "options": [],
+            "query": "from(bucket: \"racing\")\r\n  |> range(start: -1y, stop: now())\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"Gear\")\r\n  |> keep(columns: [\"user\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> first()\r\n  |> group(columns: [])\r\n  |> drop(columns: [\"_value\",\"_time\"])",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "type": "query"
+          },
+          {
+            "current": {
+              "selected": true,
+              "text": "1689569987",
+              "value": "1689569987"
+            },
+            "datasource": {
+              "type": "influxdb",
+              "uid": "${DS_RACING}"
+            },
+            "definition": "from(bucket: \"racing\")\r\n  |> range(start: -1y, stop: now())\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"CurrentLapTime\" and r._value > 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> keep(columns: [\"SessionId\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> first()\r\n  |> group(columns: [])\r\n  |> drop(columns: [\"_value\",\"_time\"])",
+            "hide": 0,
+            "includeAll": false,
+            "label": "SessionId",
+            "multi": false,
+            "name": "SessionId",
+            "options": [],
+            "query": "from(bucket: \"racing\")\r\n  |> range(start: -1y, stop: now())\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"CurrentLapTime\" and r._value > 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> keep(columns: [\"SessionId\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> first()\r\n  |> group(columns: [])\r\n  |> drop(columns: [\"_value\",\"_time\"])",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 3,
+            "type": "query"
+          },
+          {
+            "current": {
+              "selected": false,
+              "text": "1689548387591312600",
+              "value": "1689548387591312600"
+            },
+            "datasource": {
+              "type": "influxdb",
+              "uid": "${DS_RACING}"
+            },
+            "definition": "data = from(bucket: \"racing\")\r\n  |> range(start:-1y, stop: now())\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"CurrentLapTime\" and r._value >= 0)\r\n\r\nStart = data\r\n  |> first(column: \"_time\")\r\n  |> map(fn: (r) => ({r with Start: int(v: r._time)}))\r\n  |> group()  \r\n  |> keep(columns: [\"Start\"])\r\n  |> yield()",
+            "hide": 2,
+            "includeAll": false,
+            "multi": false,
+            "name": "SessionStart",
+            "options": [],
+            "query": "data = from(bucket: \"racing\")\r\n  |> range(start:-1y, stop: now())\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"CurrentLapTime\" and r._value >= 0)\r\n\r\nStart = data\r\n  |> first(column: \"_time\")\r\n  |> map(fn: (r) => ({r with Start: int(v: r._time)}))\r\n  |> group()  \r\n  |> keep(columns: [\"Start\"])\r\n  |> yield()",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "type": "query"
+          },
+          {
+            "current": {
+              "selected": false,
+              "text": "1689548838311859700",
+              "value": "1689548838311859700"
+            },
+            "datasource": {
+              "type": "influxdb",
+              "uid": "${DS_RACING}"
+            },
+            "definition": "data = from(bucket: \"racing\")\r\n  |> range(start:-1y, stop: now())\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"CurrentLapTime\" and r._value >= 0)\r\n\r\nStop = data\r\n  |> last(column: \"_time\")\r\n  |> map(fn: (r) => ({r with Stop: int(v: r._time)}))\r\n  |> group()  \r\n  |> keep(columns: [\"Stop\"])\r\n  |> yield()\r\n",
+            "hide": 2,
+            "includeAll": false,
+            "multi": false,
+            "name": "SessionEnd",
+            "options": [],
+            "query": "data = from(bucket: \"racing\")\r\n  |> range(start:-1y, stop: now())\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"CurrentLapTime\" and r._value >= 0)\r\n\r\nStop = data\r\n  |> last(column: \"_time\")\r\n  |> map(fn: (r) => ({r with Stop: int(v: r._time)}))\r\n  |> group()  \r\n  |> keep(columns: [\"Stop\"])\r\n  |> yield()\r\n",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "type": "query"
+          },
+          {
+            "current": {
+              "selected": false,
+              "text": "451",
+              "value": "451"
+            },
+            "datasource": {
+              "type": "influxdb",
+              "uid": "${DS_RACING}"
+            },
+            "definition": "import \"date\"\r\nimport \"math\"\r\ndata = from(bucket: \"racing\")\r\n  |> range(start:-1y, stop: now())\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"CurrentLapTime\" and r._value >= 0)\r\nStop = data\r\n  |> last(column: \"_time\")\r\nStart = data\r\n  |> first(column: \"_time\")\r\njoin(tables: {min: Start, max: Stop}, on: [\"SessionId\"], method: \"inner\")\r\n  |> group()  \r\n  |> map(fn: (r) => ({r with Duration: math.round(x: (float(v: int(v: duration(v: uint(v: r._time_max) - uint(v: r._time_min))))/60000000000.0)*60.0)}))\r\n  |> keep(columns: [\"Duration\"])\r\n  |> yield()  ",
+            "hide": 2,
+            "includeAll": false,
+            "multi": false,
+            "name": "SessionLen",
+            "options": [],
+            "query": "import \"date\"\r\nimport \"math\"\r\ndata = from(bucket: \"racing\")\r\n  |> range(start:-1y, stop: now())\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"CurrentLapTime\" and r._value >= 0)\r\nStop = data\r\n  |> last(column: \"_time\")\r\nStart = data\r\n  |> first(column: \"_time\")\r\njoin(tables: {min: Start, max: Stop}, on: [\"SessionId\"], method: \"inner\")\r\n  |> group()  \r\n  |> map(fn: (r) => ({r with Duration: math.round(x: (float(v: int(v: duration(v: uint(v: r._time_max) - uint(v: r._time_min))))/60000000000.0)*60.0)}))\r\n  |> keep(columns: [\"Duration\"])\r\n  |> yield()  ",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "type": "query"
+          }
+        ]
       },
-      "id": 57,
-      "panels": [],
-      "title": "Work In Progress",
-      "type": "row"
+      "time": {
+        "from": "now-3h",
+        "to": "now"
+      },
+      "timepicker": {
+        "refresh_intervals": [
+          "1m",
+          "5m",
+          "15m",
+          "30m",
+          "1h",
+          "2h",
+          "1d"
+        ]
+      },
+      "timezone": "browser",
+      "title": "B4mad Session Details",
+      "uid": "e12c7ccb-ff51-4525-b5da-0d783a1019ef",
+      "version": 104,
+      "weekStart": ""
     }
-  ],
-  "refresh": "",
-  "revision": 1,
-  "schemaVersion": 38,
-  "style": "dark",
-  "tags": [],
-  "templating": {
-    "list": [
-      {
-        "current": {
-          "selected": true,
-          "text": "Km/h",
-          "value": "3.6"
-        },
-        "hide": 0,
-        "includeAll": false,
-        "label": "Speed",
-        "multi": false,
-        "name": "Speed",
-        "options": [
-          {
-            "selected": true,
-            "text": "Km/h",
-            "value": "3.6"
-          },
-          {
-            "selected": false,
-            "text": "MPH",
-            "value": "2.236936292054"
-          }
-        ],
-        "query": "Km/h : 3.6 , MPH : 2.236936292054",
-        "queryValue": "",
-        "skipUrlSync": true,
-        "type": "custom"
-      },
-      {
-        "current": {
-          "selected": false,
-          "text": "",
-          "value": ""
-        },
-        "datasource": {
-          "type": "influxdb",
-          "uid": "${DS_RACING}"
-        },
-        "definition": "from(bucket: \"racing\")\r\n  |> range(start: -1y, stop: now())\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"Gear\")\r\n  |> keep(columns: [\"user\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> first()\r\n  |> group(columns: [])\r\n  |> drop(columns: [\"_value\",\"_time\"])",
-        "hide": 0,
-        "includeAll": false,
-        "multi": false,
-        "name": "User",
-        "options": [],
-        "query": "from(bucket: \"racing\")\r\n  |> range(start: -1y, stop: now())\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"Gear\")\r\n  |> keep(columns: [\"user\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> first()\r\n  |> group(columns: [])\r\n  |> drop(columns: [\"_value\",\"_time\"])",
-        "refresh": 2,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 1,
-        "type": "query"
-      },
-      {
-        "current": {
-          "selected": false,
-          "text": "",
-          "value": ""
-        },
-        "datasource": {
-          "type": "influxdb",
-          "uid": "${DS_RACING}"
-        },
-        "definition": "from(bucket: \"racing\")\r\n  |> range(start: -1y, stop: now())\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"CurrentLapTime\" and r._value > 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> keep(columns: [\"SessionId\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> first()\r\n  |> group(columns: [])\r\n  |> drop(columns: [\"_value\",\"_time\"])",
-        "hide": 0,
-        "includeAll": false,
-        "label": "SessionId",
-        "multi": false,
-        "name": "SessionId",
-        "options": [],
-        "query": "from(bucket: \"racing\")\r\n  |> range(start: -1y, stop: now())\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"CurrentLapTime\" and r._value > 0 )\r\n  |> filter(fn: (r) => r.user == \"${User}\")\r\n  |> keep(columns: [\"SessionId\", \"_time\", \"_value\"])\r\n  |> sort(columns: [\"_time\"], desc: false)\r\n  |> first()\r\n  |> group(columns: [])\r\n  |> drop(columns: [\"_value\",\"_time\"])",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 3,
-        "type": "query"
-      },
-      {
-        "current": {
-          "selected": false,
-          "text": "",
-          "value": ""
-        },
-        "datasource": {
-          "type": "influxdb",
-          "uid": "${DS_RACING}"
-        },
-        "definition": "data = from(bucket: \"racing\")\r\n  |> range(start:-1y, stop: now())\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"CurrentLapTime\" and r._value >= 0)\r\n\r\nStart = data\r\n  |> first(column: \"_time\")\r\n  |> map(fn: (r) => ({r with Start: int(v: r._time)}))\r\n  |> group()  \r\n  |> keep(columns: [\"Start\"])\r\n  |> yield()",
-        "hide": 2,
-        "includeAll": false,
-        "multi": false,
-        "name": "SessionStart",
-        "options": [],
-        "query": "data = from(bucket: \"racing\")\r\n  |> range(start:-1y, stop: now())\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"CurrentLapTime\" and r._value >= 0)\r\n\r\nStart = data\r\n  |> first(column: \"_time\")\r\n  |> map(fn: (r) => ({r with Start: int(v: r._time)}))\r\n  |> group()  \r\n  |> keep(columns: [\"Start\"])\r\n  |> yield()",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "type": "query"
-      },
-      {
-        "current": {
-          "selected": false,
-          "text": "",
-          "value": ""
-        },
-        "datasource": {
-          "type": "influxdb",
-          "uid": "${DS_RACING}"
-        },
-        "definition": "data = from(bucket: \"racing\")\r\n  |> range(start:-1y, stop: now())\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"CurrentLapTime\" and r._value >= 0)\r\n\r\nStop = data\r\n  |> last(column: \"_time\")\r\n  |> map(fn: (r) => ({r with Stop: int(v: r._time)}))\r\n  |> group()  \r\n  |> keep(columns: [\"Stop\"])\r\n  |> yield()\r\n",
-        "hide": 2,
-        "includeAll": false,
-        "multi": false,
-        "name": "SessionEnd",
-        "options": [],
-        "query": "data = from(bucket: \"racing\")\r\n  |> range(start:-1y, stop: now())\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"CurrentLapTime\" and r._value >= 0)\r\n\r\nStop = data\r\n  |> last(column: \"_time\")\r\n  |> map(fn: (r) => ({r with Stop: int(v: r._time)}))\r\n  |> group()  \r\n  |> keep(columns: [\"Stop\"])\r\n  |> yield()\r\n",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "type": "query"
-      },
-      {
-        "current": {
-          "selected": false,
-          "text": "",
-          "value": ""
-        },
-        "datasource": {
-          "type": "influxdb",
-          "uid": "${DS_RACING}"
-        },
-        "definition": "import \"date\"\r\nimport \"math\"\r\ndata = from(bucket: \"racing\")\r\n  |> range(start:-1y, stop: now())\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"CurrentLapTime\" and r._value >= 0)\r\nStop = data\r\n  |> last(column: \"_time\")\r\nStart = data\r\n  |> first(column: \"_time\")\r\njoin(tables: {min: Start, max: Stop}, on: [\"SessionId\"], method: \"inner\")\r\n  |> group()  \r\n  |> map(fn: (r) => ({r with Duration: math.round(x: (float(v: int(v: duration(v: uint(v: r._time_max) - uint(v: r._time_min))))/60000000000.0)*60.0)}))\r\n  |> keep(columns: [\"Duration\"])\r\n  |> yield()  ",
-        "hide": 2,
-        "includeAll": false,
-        "multi": false,
-        "name": "SessionLen",
-        "options": [],
-        "query": "import \"date\"\r\nimport \"math\"\r\ndata = from(bucket: \"racing\")\r\n  |> range(start:-1y, stop: now())\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"laps_cc\")\r\n  |> filter(fn: (r) => r[\"SessionId\"] == \"${SessionId}\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"CurrentLapTime\" and r._value >= 0)\r\nStop = data\r\n  |> last(column: \"_time\")\r\nStart = data\r\n  |> first(column: \"_time\")\r\njoin(tables: {min: Start, max: Stop}, on: [\"SessionId\"], method: \"inner\")\r\n  |> group()  \r\n  |> map(fn: (r) => ({r with Duration: math.round(x: (float(v: int(v: duration(v: uint(v: r._time_max) - uint(v: r._time_min))))/60000000000.0)*60.0)}))\r\n  |> keep(columns: [\"Duration\"])\r\n  |> yield()  ",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "type": "query"
-      },
-      {
-        "current": {
-          "selected": true,
-          "text": "${DS_RACING}",
-          "value": "${DS_RACING}"
-        },
-        "hide": 2,
-        "includeAll": false,
-        "multi": false,
-        "name": "DS_RACING",
-        "options": [],
-        "query": "influxdb",
-        "queryValue": "",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "type": "datasource"
-      }
-    ]
-  },
-  "time": {
-    "from": "now-3h",
-    "to": "now"
-  },
-  "timepicker": {
-    "refresh_intervals": [
-      "1m",
-      "5m",
-      "15m",
-      "30m",
-      "1h",
-      "2h",
-      "1d"
-    ]
-  },
-  "timezone": "browser",
-  "title": "B4mad Session Details",
-  "uid": "e12c7ccb-ff51-4525-b5da-0d783a1019ef",
-  "version": 101,
-  "weekStart": ""
-}


### PR DESCRIPTION
Ignore the other one 
Lots of changes 
-First all panels will query only the date range of the session and if most of their values are > 0 -Add table for session details with some process data  -remove limit to 0 in panel temp and psi -change the thresholds of wear (was using the same as psi) -add pitlimit on the speed panel -lower the fill of inputs panel 
-change Engine PSI thresholds because was using the same as Type  -Add Rain (but i haven't seem shown on cc data) -Flags Data mapping (WIP)
-more that i don't remember