### PR TITLE
sm paddock metrics

### DIFF
--- a/components/paddock/paddock/settings.py
+++ b/components/paddock/paddock/settings.py
@@ -46,11 +46,16 @@ SECRET_KEY = env("SECRET_KEY")
 # https://github.com/korfuri/django-prometheus#monitoring-your-models
 PROMETHEUS_EXPORT_MIGRATIONS = False
 
+# PADDOCK_POD_IP might be set via kubernetes downward API
+# https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/
+# and https://github.com/korfuri/django-prometheus/issues/81
+# ALLOWED_HOST might be set via kubernetes deployment env
 ALLOWED_HOSTS = [
     "127.0.0.1",
     "localhost",
     "paddock.b4mad.racing",
     os.environ.get("ALLOWED_HOST", ""),
+    os.environ.get("PADDOCK_POD_IP", ""),
 ]
 
 

--- a/manifests/base/paddock/deployment_config.yaml
+++ b/manifests/base/paddock/deployment_config.yaml
@@ -57,6 +57,10 @@ spec:
                 secretKeyRef:
                   name: db-pguser-paddock
                   key: dbname
+            - name: PADDOCK_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
           envFrom:
             - secretRef:
                 name: paddock-settings

--- a/manifests/env/nostromo-stage/kustomization.yaml
+++ b/manifests/env/nostromo-stage/kustomization.yaml
@@ -29,3 +29,5 @@ images:
   - name: paddock
     newName: image-registry.openshift-image-registry.svc:5000/b4mad-racing-stage/paddock
     newTag: latest
+  - name: docker.io/eclipse-mosquitto
+    newTag: "2.0.16-openssl"


### PR DESCRIPTION
- :sparkles: update mosquitto version to 2.0.16
- ✨ introducing PADDOCK_POD_IP as an allowed host, so that user workload monitoring of OpenShift (prometheus) can scrap the metric
