### PR TITLE
reenable paddock metrics

### DIFF
--- a/components/paddock/CHANGELOG.md
+++ b/components/paddock/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG
 
+## v0.6.1-rc1 (2023-09-13)
+
+### Feat
+
+- add alerting for pgsql diff backup cronjob execution and pvc usage
+
+### Fix
+
+- paddock labels normalized
+- paddock job name for 'up' metric
+
 ## v0.6.1-rc0 (2023-09-11)
 
 ### Fix

--- a/components/paddock/paddock/urls.py
+++ b/components/paddock/paddock/urls.py
@@ -14,6 +14,7 @@ from .views import CoachView
 
 urlpatterns = [
     # path("", views.index, name="home"),
+    path("", include("django_prometheus.urls")),
     path("", TemplateView.as_view(template_name="home.html"), name="home"),
     # path('pitcrew', TemplateView.as_view(template_name='pitcrew.html'), name="pitcrew"),
     # path("fastlap/<str:game>/<str:track>/<str:car>", views.fastlap_index, name="fastlap_index"),

--- a/components/paddock/pyproject.toml
+++ b/components/paddock/pyproject.toml
@@ -6,7 +6,7 @@ description = "This is the #B4mad Racing Paddock."
 license = {text = "GPL-3.0-or-later"}
 name = "paddock"
 readme = "README.md"
-version = "0.6.1-rc0"
+version = "0.6.1-rc1"
 
 [tool.isort]
 default_section = "THIRDPARTY"


### PR DESCRIPTION
- bump: version 0.6.1-rc0 → 0.6.1-rc1
- feat: provide operational metrics for paddock
