### PR TITLE
adjust sentry logging

### DIFF
--- a/components/paddock/paddock/settings.py
+++ b/components/paddock/paddock/settings.py
@@ -2,6 +2,7 @@
 Django settings for paddock project.
 """
 
+import logging
 import os
 import sys
 from pathlib import Path
@@ -9,6 +10,7 @@ from pathlib import Path
 import environ
 import sentry_sdk
 from sentry_sdk.integrations.django import DjangoIntegration
+from sentry_sdk.integrations.logging import LoggingIntegration
 
 env = environ.Env(
     # set casting, default value
@@ -338,7 +340,8 @@ sentry_dsn = os.environ.get("SENTRY_DSN")
 if sentry_dsn and sentry_dsn.startswith("http"):
     sentry_sdk.init(
         dsn=sentry_dsn,
-        integrations=[DjangoIntegration()],
+        default_integrations=False,
+        integrations=[DjangoIntegration(), LoggingIntegration(level=logging.CRITICAL)],
         # If you wish to associate users to errors (assuming you are using
         # django.contrib.auth) you may enable sending PII data.
         send_default_pii=True,


### PR DESCRIPTION
@goern would this still send uncaught exceptions, but no logging.ERROR messages?
Are there any other default_integrations we want to add?

/assign @goern 