### PR TITLE
Update CPU limit to 1000m

### DIFF
--- a/manifests/env/phobos/influxdb/kustomization.yaml
+++ b/manifests/env/phobos/influxdb/kustomization.yaml
@@ -35,7 +35,7 @@ patches:
   - patch: |-
       - op: replace
         path: /spec/template/spec/containers/0/resources/limits/cpu
-        value: "2000m"
+        value: "1000m"
       - op: replace
         path: /spec/template/spec/containers/0/resources/limits/memory
         value: "16Gi"


### PR DESCRIPTION
This pull request updates the CPU limit to 1000m. This change ensures that the CPU limit for the specified container is set to 1000m, which will help optimize resource allocation and improve performance.

